### PR TITLE
Add tax metadata and declarative tax report MVP

### DIFF
--- a/docs/tax-reporting-strategy.md
+++ b/docs/tax-reporting-strategy.md
@@ -1,0 +1,118 @@
+# Tax reporting strategy
+
+This feature is designed as a declarative tax review helper, not as a tax calculator.
+
+The goal is to help the user avoid forgetting potentially reportable accounts, foreign income, withholding tax, credits or declaration forms. The app must not pretend to compute final tax liability or provide legal/tax advice.
+
+## Initial jurisdictions
+
+The MVP supports rule modules for:
+
+- France
+- Canada federal
+- Quebec
+
+A Canadian profile with `residenceCountry = CA` and `residenceRegion = QC` runs both Canada federal and Quebec checks.
+
+## Data model
+
+### Tax profile
+
+A `TaxProfile` represents the user's tax residency for a specific tax year.
+
+Important fields:
+
+- `year`
+- `residenceCountry`
+- `residenceRegion`
+- `currency`
+
+Tax residency is intentionally annual because a user can move between jurisdictions from one tax year to another.
+
+### Account metadata
+
+Accounts can now carry jurisdiction metadata:
+
+- `institutionCountry`
+- `institutionRegion`
+- `taxReportingType`
+- `openedAt`
+- `closedAt`
+
+`institutionCountry` describes where the account or institution exists. It does not describe the user's tax residency.
+
+### Transaction metadata
+
+Income transactions can now carry tax metadata:
+
+- `taxCategory`
+- `taxSourceCountry`
+- `taxSourceRegion`
+- `taxTreatment`
+- `taxWithheldAmount`
+- `taxWithheldCurrency`
+- `taxWithheldCountry`
+- `taxDocumentRef`
+
+The feature deliberately avoids a boolean such as `alreadyTaxed`. The safer model is explicit withholding metadata: amount, currency, country, document reference and review status.
+
+## Report rules
+
+The report engine lives in `src/utils/taxReport.ts`.
+
+It returns structured sections with:
+
+- jurisdiction
+- severity
+- items
+- suggested forms or lines to verify
+- confidence level
+
+### France MVP
+
+The France rules detect:
+
+- accounts outside France, potentially reportable through 3916 / 3916-bis
+- foreign-source income, potentially reportable through 2047 / 2042
+- foreign tax withheld, potentially relevant for foreign tax credit or treaty mechanisms
+
+### Canada federal MVP
+
+The Canada federal rules detect:
+
+- accounts or assets outside Canada, potentially relevant for T1135 review
+- foreign-source income
+- foreign tax withheld, potentially relevant for federal foreign tax credit review
+
+### Quebec MVP
+
+The Quebec rules detect:
+
+- income earned outside Quebec
+- foreign or non-Quebec tax withheld
+- potential Quebec foreign tax credit or interprovincial transfer review
+
+## UX rule
+
+Wording must remain conservative:
+
+- use “to verify” and “review required”
+- do not say “you must declare X on line Y” unless the rule is made authoritative and maintained
+- do not compute final tax owed
+
+## Persistence
+
+JSON backups are versioned as `version: 4` and include the tax metadata fields. Older backups remain accepted for restore parsing.
+
+CSV import/export should expose the tax fields in a future follow-up so imports do not silently drop user-provided tax metadata.
+
+## Tests
+
+The rule engine is covered by `src/utils/taxReport.test.ts`.
+
+The key covered cases are:
+
+- French resident with foreign account, foreign income and foreign withholding
+- tax-year filtering
+- Quebec resident receiving Canada federal and Quebec sections
+- Markdown export serialization

--- a/electron/ipc/registerTaxHandlers.js
+++ b/electron/ipc/registerTaxHandlers.js
@@ -1,0 +1,199 @@
+const {ipcMain} = require('electron')
+const {getPrisma} = require('../db')
+
+function normalizeText(value) {
+    if (typeof value !== 'string') return null
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+}
+
+function normalizeCountry(value) {
+    return normalizeText(value)?.toUpperCase() || null
+}
+
+function normalizeRegion(value) {
+    return normalizeText(value)?.toUpperCase() || null
+}
+
+function normalizeCurrency(value, fallback = 'CAD') {
+    return (normalizeText(value) || fallback).toUpperCase()
+}
+
+function requireId(value, fieldName) {
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`${fieldName} est invalide.`)
+    }
+    return parsed
+}
+
+function requireYear(value) {
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < 1900 || parsed > 2200) {
+        throw new Error("L'année fiscale est invalide.")
+    }
+    return parsed
+}
+
+function requireCountry(value, fieldName = 'Le pays') {
+    const country = normalizeCountry(value)
+    if (!country) {
+        throw new Error(`${fieldName} est obligatoire.`)
+    }
+    return country
+}
+
+function optionalDate(value, fieldName) {
+    if (value == null || value === '') return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`${fieldName} est invalide.`)
+    }
+    return parsed
+}
+
+function optionalNonNegativeNumber(value, fieldName) {
+    if (value == null || value === '') return null
+    const parsed = Number(value)
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(`${fieldName} doit être un nombre positif ou nul.`)
+    }
+    return parsed
+}
+
+function normalizeEnum(value, allowed, fallback = null) {
+    const normalized = normalizeText(value)?.toUpperCase()
+    if (!normalized) return fallback
+    return allowed.includes(normalized) ? normalized : fallback
+}
+
+const accountTaxReportingTypes = [
+    'STANDARD',
+    'BANK',
+    'CASH',
+    'BROKERAGE',
+    'CRYPTO',
+    'LIFE_INSURANCE',
+    'RETIREMENT',
+    'LOAN',
+    'OTHER',
+]
+
+const taxIncomeCategories = [
+    'EMPLOYMENT',
+    'BUSINESS',
+    'INTEREST',
+    'DIVIDEND',
+    'CAPITAL_GAIN',
+    'RENTAL',
+    'PENSION',
+    'BENEFIT',
+    'GIFT',
+    'REFUND',
+    'TRANSFER',
+    'OTHER',
+]
+
+const taxTreatments = [
+    'UNKNOWN',
+    'NOT_TAXABLE',
+    'TAXABLE_NO_WITHHOLDING',
+    'TAX_WITHHELD_AT_SOURCE',
+    'FOREIGN_TAX_CREDIT_CANDIDATE',
+    'TREATY_EXEMPT_CANDIDATE',
+    'REVIEW_REQUIRED',
+]
+
+function buildTaxProfilePayload(data) {
+    return {
+        year: requireYear(data?.year),
+        residenceCountry: requireCountry(data?.residenceCountry, 'Le pays de résidence fiscale'),
+        residenceRegion: normalizeRegion(data?.residenceRegion),
+        currency: normalizeCurrency(data?.currency),
+    }
+}
+
+function buildAccountTaxMetadataPayload(data) {
+    return {
+        institutionCountry: normalizeCountry(data?.institutionCountry),
+        institutionRegion: normalizeRegion(data?.institutionRegion),
+        taxReportingType: normalizeEnum(data?.taxReportingType, accountTaxReportingTypes, 'STANDARD'),
+        openedAt: optionalDate(data?.openedAt, "La date d'ouverture"),
+        closedAt: optionalDate(data?.closedAt, 'La date de fermeture'),
+    }
+}
+
+function buildTransactionTaxMetadataPayload(data) {
+    const taxWithheldAmount = optionalNonNegativeNumber(data?.taxWithheldAmount, "L'impôt retenu")
+
+    return {
+        taxCategory: normalizeEnum(data?.taxCategory, taxIncomeCategories, null),
+        taxSourceCountry: normalizeCountry(data?.taxSourceCountry),
+        taxSourceRegion: normalizeRegion(data?.taxSourceRegion),
+        taxTreatment: normalizeEnum(data?.taxTreatment, taxTreatments, 'UNKNOWN'),
+        taxWithheldAmount,
+        taxWithheldCurrency: taxWithheldAmount == null
+            ? normalizeCountry(data?.taxWithheldCurrency)
+            : normalizeCurrency(data?.taxWithheldCurrency),
+        taxWithheldCountry: normalizeCountry(data?.taxWithheldCountry),
+        taxDocumentRef: normalizeText(data?.taxDocumentRef),
+    }
+}
+
+function includeTransactionRelations() {
+    return {
+        account: true,
+        category: true,
+        transferPeerAccount: true,
+    }
+}
+
+function registerTaxHandlers() {
+    const prisma = getPrisma()
+
+    ipcMain.handle('db:taxProfile:list', async () => {
+        return prisma.taxProfile.findMany({
+            orderBy: [
+                {year: 'desc'},
+                {residenceCountry: 'asc'},
+                {residenceRegion: 'asc'},
+            ],
+        })
+    })
+
+    ipcMain.handle('db:taxProfile:create', async (_event, data) => {
+        return prisma.taxProfile.create({
+            data: buildTaxProfilePayload(data),
+        })
+    })
+
+    ipcMain.handle('db:taxProfile:update', async (_event, id, data) => {
+        return prisma.taxProfile.update({
+            where: {id: requireId(id, 'Le profil fiscal')},
+            data: buildTaxProfilePayload(data),
+        })
+    })
+
+    ipcMain.handle('db:taxProfile:delete', async (_event, id) => {
+        return prisma.taxProfile.delete({
+            where: {id: requireId(id, 'Le profil fiscal')},
+        })
+    })
+
+    ipcMain.handle('db:taxMetadata:updateAccount', async (_event, id, data) => {
+        return prisma.account.update({
+            where: {id: requireId(id, 'Le compte')},
+            data: buildAccountTaxMetadataPayload(data),
+        })
+    })
+
+    ipcMain.handle('db:taxMetadata:updateTransaction', async (_event, id, data) => {
+        return prisma.transaction.update({
+            where: {id: requireId(id, 'La transaction')},
+            data: buildTransactionTaxMetadataPayload(data),
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+module.exports = {registerTaxHandlers}

--- a/electron/ipc/registerTaxHandlers.js
+++ b/electron/ipc/registerTaxHandlers.js
@@ -133,7 +133,7 @@ function buildTransactionTaxMetadataPayload(data) {
         taxTreatment: normalizeEnum(data?.taxTreatment, taxTreatments, 'UNKNOWN'),
         taxWithheldAmount,
         taxWithheldCurrency: taxWithheldAmount == null
-            ? normalizeCountry(data?.taxWithheldCurrency)
+            ? null
             : normalizeCurrency(data?.taxWithheldCurrency),
         taxWithheldCountry: normalizeCountry(data?.taxWithheldCountry),
         taxDocumentRef: normalizeText(data?.taxDocumentRef),

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,7 @@ const {registerBudgetHandlers} = require('./ipc/registerBudgetHandlers')
 const {registerRecurringHandlers} = require('./ipc/registerRecurringHandlers')
 const {registerFileHandlers} = require('./ipc/registerFileHandlers')
 const {registerFxHandlers} = require('./ipc/registerFxHandlers')
+const {registerTaxHandlers} = require('./ipc/registerTaxHandlers')
 const {disconnectPrisma} = require('./db')
 const {getMenuMessages, normalizeMenuLocale} = require('./menuI18n')
 
@@ -249,6 +250,7 @@ app.whenReady().then(() => {
     registerRecurringHandlers()
     registerFileHandlers()
     registerFxHandlers()
+    registerTaxHandlers()
 
     Menu.setApplicationMenu(buildAppMenu(currentMenuLocale))
     createWindow()

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -46,6 +46,16 @@ contextBridge.exposeInMainWorld('db', {
         delete: (id) => ipcRenderer.invoke('db:recurringTemplate:delete', id),
         generateDue: (data) => ipcRenderer.invoke('db:recurringTemplate:generateDue', data),
     },
+    taxProfile: {
+        list: () => ipcRenderer.invoke('db:taxProfile:list'),
+        create: (data) => ipcRenderer.invoke('db:taxProfile:create', data),
+        update: (id, data) => ipcRenderer.invoke('db:taxProfile:update', id, data),
+        delete: (id) => ipcRenderer.invoke('db:taxProfile:delete', id),
+    },
+    taxMetadata: {
+        updateAccount: (id, data) => ipcRenderer.invoke('db:taxMetadata:updateAccount', id, data),
+        updateTransaction: (id, data) => ipcRenderer.invoke('db:taxMetadata:updateTransaction', id, data),
+    },
 })
 
 contextBridge.exposeInMainWorld('file', {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,11 @@ model Account {
   type                AccountType
   currency            String                         @default("CAD")
   description         String?
+  institutionCountry  String?
+  institutionRegion   String?
+  taxReportingType    AccountTaxReportingType        @default(STANDARD)
+  openedAt            DateTime?
+  closedAt            DateTime?
   createdAt           DateTime                       @default(now())
   updatedAt           DateTime                       @updatedAt
   transactions        Transaction[]
@@ -46,6 +51,14 @@ model Transaction {
   kind             TransactionKind
   date             DateTime
   note             String?
+  taxCategory      TaxIncomeCategory?
+  taxSourceCountry String?
+  taxSourceRegion  String?
+  taxTreatment     TaxTreatment    @default(UNKNOWN)
+  taxWithheldAmount   Float?
+  taxWithheldCurrency String?
+  taxWithheldCountry  String?
+  taxDocumentRef      String?
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
 
@@ -59,6 +72,18 @@ model Transaction {
   transferDirection     TransferDirection?
   transferPeerAccountId Int?
   transferPeerAccount   Account?           @relation("TransactionTransferPeer", fields: [transferPeerAccountId], references: [id], onDelete: SetNull)
+}
+
+model TaxProfile {
+  id               Int      @id @default(autoincrement())
+  year             Int
+  residenceCountry String
+  residenceRegion  String?
+  currency         String   @default("CAD")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([year, residenceCountry, residenceRegion])
 }
 
 model BudgetTarget {
@@ -114,6 +139,18 @@ enum AccountType {
   OTHER
 }
 
+enum AccountTaxReportingType {
+  STANDARD
+  BANK
+  CASH
+  BROKERAGE
+  CRYPTO
+  LIFE_INSURANCE
+  RETIREMENT
+  LOAN
+  OTHER
+}
+
 enum TransactionKind {
   INCOME
   EXPENSE
@@ -142,4 +179,29 @@ enum RecurringFrequency {
 enum TransferDirection {
   OUT
   IN
+}
+
+enum TaxIncomeCategory {
+  EMPLOYMENT
+  BUSINESS
+  INTEREST
+  DIVIDEND
+  CAPITAL_GAIN
+  RENTAL
+  PENSION
+  BENEFIT
+  GIFT
+  REFUND
+  TRANSFER
+  OTHER
+}
+
+enum TaxTreatment {
+  UNKNOWN
+  NOT_TAXABLE
+  TAXABLE_NO_WITHHOLDING
+  TAX_WITHHELD_AT_SOURCE
+  FOREIGN_TAX_CREDIT_CANDIDATE
+  TREATY_EXEMPT_CANDIDATE
+  REVIEW_REQUIRED
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import OverviewSection from './components/OverviewSection.vue'
 import RecurringSection from './components/RecurringSection.vue'
 import ReportsSection from './components/ReportsSection.vue'
 import SettingsDialog from './components/SettingsDialog.vue'
+import TaxReportPanel from './components/TaxReportPanel.vue'
 import TransactionsSection from './components/TransactionsSection.vue'
 import {useBudgetData} from './composables/useBudgetData'
 import {useBudgetTargets} from './composables/useBudgetTargets'
@@ -20,10 +21,11 @@ import {useJsonBackup} from './composables/useJsonBackup'
 import {useRecurringTemplates} from './composables/useRecurringTemplates'
 import {useReports} from './composables/useReports'
 import {useSettings} from './composables/useSettings'
-import type {CreateTabKey, ReportPreset, SectionKey} from './types/budget'
+import type {CreateTabKey, ReportPreset, SectionKey, TaxProfile} from './types/budget'
 
 const notice = ref<{ type: 'success' | 'error'; text: string } | null>(null)
 const appVersion = ref('')
+const taxProfiles = ref<TaxProfile[]>([])
 
 function showNotice(type: 'success' | 'error', text: string) {
   notice.value = {type, text}
@@ -32,6 +34,13 @@ function showNotice(type: 'success' | 'error', text: string) {
       notice.value = null
     }
   }, 3600)
+}
+
+function normalizeError(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return t('notices.unknownError')
 }
 
 const {t} = useI18n()
@@ -69,11 +78,20 @@ const reports = useReports({
   showNotice,
 })
 
+async function refreshTaxProfiles() {
+  try {
+    taxProfiles.value = await window.db.taxProfile.list()
+  } catch (error) {
+    showNotice('error', normalizeError(error))
+  }
+}
+
 function refreshEverything() {
   return Promise.all([
     budget.refreshData(),
     budgetTargets.refreshBudgets(),
     recurring.refreshRecurringTemplates(),
+    refreshTaxProfiles(),
   ])
 }
 
@@ -83,6 +101,7 @@ const jsonBackup = useJsonBackup({
   budgetTargets: budgetTargets.budgets,
   recurringTemplates: recurring.recurringTemplates,
   transactions: budget.transactions,
+  taxProfiles,
   refreshAllData: refreshEverything,
   showNotice,
 })
@@ -484,24 +503,35 @@ onMounted(async () => {
               @submit-template="recurring.submitRecurring"
           />
 
-          <ReportsSection
-              v-else
-              :preset="reports.reportPreset.value"
-              :start-date="reports.reportStartDate.value"
-              :end-date="reports.reportEndDate.value"
-              :summary="reports.reportSummary.value"
-              :comparison="reports.reportComparison.value"
-              :account-type-rows="reports.accountTypeRows.value"
-              :account-rows="reports.accountRows.value"
-              :category-rows="reports.categoryRows.value"
-              :foreign-currency-rows="reports.foreignCurrencyRows.value"
-              :weekday-rows="reports.weekdayRows.value"
-              :insights="reports.insights.value"
-              @set-preset="reports.applyPreset($event as ReportPreset)"
-              @update:start-date="reports.reportStartDate.value = $event"
-              @update:end-date="reports.reportEndDate.value = $event"
-              @export-report="reports.exportPeriodReport"
-          />
+          <template v-else>
+            <ReportsSection
+                :preset="reports.reportPreset.value"
+                :start-date="reports.reportStartDate.value"
+                :end-date="reports.reportEndDate.value"
+                :summary="reports.reportSummary.value"
+                :comparison="reports.reportComparison.value"
+                :account-type-rows="reports.accountTypeRows.value"
+                :account-rows="reports.accountRows.value"
+                :category-rows="reports.categoryRows.value"
+                :foreign-currency-rows="reports.foreignCurrencyRows.value"
+                :weekday-rows="reports.weekdayRows.value"
+                :insights="reports.insights.value"
+                @set-preset="reports.applyPreset($event as ReportPreset)"
+                @update:start-date="reports.reportStartDate.value = $event"
+                @update:end-date="reports.reportEndDate.value = $event"
+                @export-report="reports.exportPeriodReport"
+            />
+
+            <div class="mt-6">
+              <TaxReportPanel
+                  :accounts="budget.accounts.value"
+                  :transactions="budget.transactions.value"
+                  :tax-profiles="taxProfiles"
+                  @refresh-tax-profiles="refreshTaxProfiles"
+                  @refresh-data="budget.refreshData"
+              />
+            </div>
+          </template>
         </main>
       </div>
     </div>

--- a/src/components/TaxReportPanel.vue
+++ b/src/components/TaxReportPanel.vue
@@ -1,0 +1,509 @@
+<script setup lang="ts">
+import {computed, reactive, ref, watch} from 'vue'
+import type {
+  Account,
+  AccountTaxReportingType,
+  TaxIncomeCategory,
+  TaxProfile,
+  TaxTreatment,
+  Transaction,
+} from '../types/budget'
+import {formatMoney} from '../utils/budgetFormat'
+import {toDateOnly} from '../utils/date'
+import {buildTaxReport, taxReportToMarkdown} from '../utils/taxReport'
+
+const props = defineProps<{
+  accounts: Account[]
+  transactions: Transaction[]
+  taxProfiles: TaxProfile[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'refresh-tax-profiles'): void
+  (e: 'refresh-data'): void
+}>()
+
+const selectedTaxProfileId = ref('')
+const savingProfile = ref(false)
+const savingAccountId = ref<number | null>(null)
+const savingTransactionId = ref<number | null>(null)
+const notice = ref<{type: 'success' | 'error'; text: string} | null>(null)
+
+const currentYear = new Date().getFullYear()
+
+const taxProfileForm = reactive({
+  year: String(currentYear),
+  residenceCountry: 'CA',
+  residenceRegion: 'QC',
+  currency: 'CAD',
+})
+
+const accountForms = reactive<Record<number, {
+  institutionCountry: string
+  institutionRegion: string
+  taxReportingType: AccountTaxReportingType
+  openedAt: string
+  closedAt: string
+}>>({})
+
+const transactionForms = reactive<Record<number, {
+  taxCategory: TaxIncomeCategory | ''
+  taxSourceCountry: string
+  taxSourceRegion: string
+  taxTreatment: TaxTreatment
+  taxWithheldAmount: string
+  taxWithheldCurrency: string
+  taxWithheldCountry: string
+  taxDocumentRef: string
+}>>({})
+
+const accountTaxReportingTypes: AccountTaxReportingType[] = [
+  'STANDARD',
+  'BANK',
+  'CASH',
+  'BROKERAGE',
+  'CRYPTO',
+  'LIFE_INSURANCE',
+  'RETIREMENT',
+  'LOAN',
+  'OTHER',
+]
+
+const taxIncomeCategories: TaxIncomeCategory[] = [
+  'EMPLOYMENT',
+  'BUSINESS',
+  'INTEREST',
+  'DIVIDEND',
+  'CAPITAL_GAIN',
+  'RENTAL',
+  'PENSION',
+  'BENEFIT',
+  'GIFT',
+  'REFUND',
+  'OTHER',
+]
+
+const taxTreatments: TaxTreatment[] = [
+  'UNKNOWN',
+  'NOT_TAXABLE',
+  'TAXABLE_NO_WITHHOLDING',
+  'TAX_WITHHELD_AT_SOURCE',
+  'FOREIGN_TAX_CREDIT_CANDIDATE',
+  'TREATY_EXEMPT_CANDIDATE',
+  'REVIEW_REQUIRED',
+]
+
+function showNotice(type: 'success' | 'error', text: string) {
+  notice.value = {type, text}
+  window.setTimeout(() => {
+    if (notice.value?.text === text) {
+      notice.value = null
+    }
+  }, 3200)
+}
+
+function normalizeCode(value: string) {
+  return value.trim().toUpperCase()
+}
+
+function normalizeOptionalCode(value: string) {
+  const normalized = normalizeCode(value)
+  return normalized || null
+}
+
+function toDateInput(value: string | null | undefined) {
+  return value ? toDateOnly(value) : ''
+}
+
+function hydrateAccountForms() {
+  for (const account of props.accounts) {
+    accountForms[account.id] = {
+      institutionCountry: account.institutionCountry || '',
+      institutionRegion: account.institutionRegion || '',
+      taxReportingType: account.taxReportingType || 'STANDARD',
+      openedAt: toDateInput(account.openedAt),
+      closedAt: toDateInput(account.closedAt),
+    }
+  }
+}
+
+function hydrateTransactionForms() {
+  for (const transaction of props.transactions) {
+    transactionForms[transaction.id] = {
+      taxCategory: transaction.taxCategory || '',
+      taxSourceCountry: transaction.taxSourceCountry || '',
+      taxSourceRegion: transaction.taxSourceRegion || '',
+      taxTreatment: transaction.taxTreatment || 'UNKNOWN',
+      taxWithheldAmount: transaction.taxWithheldAmount == null ? '' : String(transaction.taxWithheldAmount),
+      taxWithheldCurrency: transaction.taxWithheldCurrency || transaction.sourceCurrency || transaction.account?.currency || '',
+      taxWithheldCountry: transaction.taxWithheldCountry || '',
+      taxDocumentRef: transaction.taxDocumentRef || '',
+    }
+  }
+}
+
+watch(() => props.accounts, hydrateAccountForms, {immediate: true, deep: true})
+watch(() => props.transactions, hydrateTransactionForms, {immediate: true, deep: true})
+watch(() => props.taxProfiles, () => {
+  if (!selectedTaxProfileId.value && props.taxProfiles.length) {
+    selectedTaxProfileId.value = String(props.taxProfiles[0].id)
+  }
+}, {immediate: true, deep: true})
+
+const selectedTaxProfile = computed(() =>
+    props.taxProfiles.find((profile) => String(profile.id) === selectedTaxProfileId.value) || null,
+)
+
+const taxReport = computed(() => selectedTaxProfile.value
+    ? buildTaxReport(selectedTaxProfile.value, props.accounts, props.transactions)
+    : null,
+)
+
+const incomeTransactionsForSelectedYear = computed(() => {
+  const profile = selectedTaxProfile.value
+  if (!profile) return props.transactions.filter((transaction) => transaction.kind === 'INCOME').slice(0, 20)
+
+  return props.transactions
+      .filter((transaction) => {
+        if (transaction.kind !== 'INCOME') return false
+        return new Date(transaction.date).getUTCFullYear() === profile.year
+      })
+      .slice(0, 50)
+})
+
+async function submitTaxProfile() {
+  const year = Number(taxProfileForm.year)
+  if (!Number.isInteger(year) || year < 1900 || year > 2200) {
+    showNotice('error', "L'année fiscale est invalide.")
+    return
+  }
+
+  if (!normalizeCode(taxProfileForm.residenceCountry)) {
+    showNotice('error', 'Le pays de résidence fiscale est obligatoire.')
+    return
+  }
+
+  savingProfile.value = true
+  try {
+    const created = await window.db.taxProfile.create({
+      year,
+      residenceCountry: normalizeCode(taxProfileForm.residenceCountry),
+      residenceRegion: normalizeOptionalCode(taxProfileForm.residenceRegion),
+      currency: normalizeCode(taxProfileForm.currency) || 'CAD',
+    })
+    selectedTaxProfileId.value = String(created.id)
+    emit('refresh-tax-profiles')
+    showNotice('success', 'Profil fiscal créé.')
+  } catch (error) {
+    showNotice('error', error instanceof Error ? error.message : 'Création du profil fiscal impossible.')
+  } finally {
+    savingProfile.value = false
+  }
+}
+
+async function saveAccountTaxMetadata(account: Account) {
+  const form = accountForms[account.id]
+  if (!form) return
+
+  savingAccountId.value = account.id
+  try {
+    await window.db.taxMetadata.updateAccount(account.id, {
+      institutionCountry: normalizeOptionalCode(form.institutionCountry),
+      institutionRegion: normalizeOptionalCode(form.institutionRegion),
+      taxReportingType: form.taxReportingType,
+      openedAt: form.openedAt || null,
+      closedAt: form.closedAt || null,
+    })
+    emit('refresh-data')
+    showNotice('success', `Métadonnées fiscales enregistrées pour ${account.name}.`)
+  } catch (error) {
+    showNotice('error', error instanceof Error ? error.message : 'Sauvegarde impossible.')
+  } finally {
+    savingAccountId.value = null
+  }
+}
+
+async function saveTransactionTaxMetadata(transaction: Transaction) {
+  const form = transactionForms[transaction.id]
+  if (!form) return
+
+  const withheldAmount = form.taxWithheldAmount.trim() ? Number(form.taxWithheldAmount) : null
+  if (withheldAmount != null && (!Number.isFinite(withheldAmount) || withheldAmount < 0)) {
+    showNotice('error', "Le montant d'impôt retenu est invalide.")
+    return
+  }
+
+  savingTransactionId.value = transaction.id
+  try {
+    await window.db.taxMetadata.updateTransaction(transaction.id, {
+      taxCategory: form.taxCategory || null,
+      taxSourceCountry: normalizeOptionalCode(form.taxSourceCountry),
+      taxSourceRegion: normalizeOptionalCode(form.taxSourceRegion),
+      taxTreatment: form.taxTreatment,
+      taxWithheldAmount: withheldAmount,
+      taxWithheldCurrency: withheldAmount == null ? null : (normalizeCode(form.taxWithheldCurrency) || transaction.sourceCurrency || transaction.account?.currency || 'CAD'),
+      taxWithheldCountry: normalizeOptionalCode(form.taxWithheldCountry),
+      taxDocumentRef: form.taxDocumentRef.trim() || null,
+    })
+    emit('refresh-data')
+    showNotice('success', `Métadonnées fiscales enregistrées pour ${transaction.label}.`)
+  } catch (error) {
+    showNotice('error', error instanceof Error ? error.message : 'Sauvegarde impossible.')
+  } finally {
+    savingTransactionId.value = null
+  }
+}
+
+async function exportTaxReport() {
+  if (!taxReport.value) {
+    showNotice('error', 'Crée ou sélectionne un profil fiscal avant export.')
+    return
+  }
+
+  const profile = taxReport.value.profile
+  const result = await window.file.saveText({
+    title: 'Exporter le rapport fiscal',
+    defaultPath: `budget-tax-report-${profile.year}-${profile.residenceCountry}${profile.residenceRegion ? `-${profile.residenceRegion}` : ''}.md`,
+    content: taxReportToMarkdown(taxReport.value),
+    filters: [{name: 'Markdown', extensions: ['md']}],
+  })
+
+  if (!result?.canceled) {
+    showNotice('success', 'Rapport fiscal exporté.')
+  }
+}
+</script>
+
+<template>
+  <section class="panel p-6">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <p class="soft-kicker">Fiscalité</p>
+        <h3 class="mt-2 text-xl font-bold text-slate-900 dark:text-white">
+          Rapport déclaratif France / Canada / Québec
+        </h3>
+        <p class="mt-2 max-w-3xl text-sm text-slate-500 dark:text-slate-400">
+          Ce module ne calcule pas l'impôt final. Il identifie les comptes, revenus, retenues à la source et formulaires à vérifier.
+        </p>
+      </div>
+
+      <button class="primary-btn" :disabled="!taxReport" @click="exportTaxReport">
+        Export fiscal Markdown
+      </button>
+    </div>
+
+    <div v-if="notice" class="mt-4 notice" :class="notice.type === 'success' ? 'notice-success' : 'notice-error'">
+      {{ notice.text }}
+    </div>
+
+    <div class="mt-6 grid gap-5 xl:grid-cols-12">
+      <section class="mini-card xl:col-span-5">
+        <p class="mini-label">Profil fiscal annuel</p>
+
+        <div v-if="taxProfiles.length" class="mt-4 field-block">
+          <label class="field-label">Profil utilisé pour le rapport</label>
+          <select v-model="selectedTaxProfileId" class="field-control">
+            <option v-for="profile in taxProfiles" :key="profile.id" :value="String(profile.id)">
+              {{ profile.year }} · {{ profile.residenceCountry }}{{ profile.residenceRegion ? `-${profile.residenceRegion}` : '' }} · {{ profile.currency }}
+            </option>
+          </select>
+        </div>
+
+        <form class="mt-5 grid gap-4 md:grid-cols-2" @submit.prevent="submitTaxProfile">
+          <label class="field-block">
+            <span class="field-label">Année</span>
+            <input v-model="taxProfileForm.year" type="number" min="1900" max="2200" class="field-control">
+          </label>
+
+          <label class="field-block">
+            <span class="field-label">Devise</span>
+            <input v-model="taxProfileForm.currency" type="text" maxlength="6" class="field-control" placeholder="CAD">
+          </label>
+
+          <label class="field-block">
+            <span class="field-label">Pays résidence</span>
+            <select v-model="taxProfileForm.residenceCountry" class="field-control">
+              <option value="FR">France</option>
+              <option value="CA">Canada</option>
+            </select>
+          </label>
+
+          <label class="field-block">
+            <span class="field-label">Région / province</span>
+            <input v-model="taxProfileForm.residenceRegion" type="text" maxlength="12" class="field-control" placeholder="QC">
+          </label>
+
+          <div class="md:col-span-2">
+            <button class="ghost-btn" type="submit" :disabled="savingProfile">
+              {{ savingProfile ? 'Création…' : 'Créer le profil fiscal' }}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="mini-card xl:col-span-7">
+        <p class="mini-label">Synthèse</p>
+
+        <div v-if="taxReport" class="mt-4 grid gap-3 md:grid-cols-3">
+          <div class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+            <p class="text-xs text-slate-500 dark:text-slate-400">Sections</p>
+            <p class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">{{ taxReport.sections.length }}</p>
+          </div>
+          <div class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+            <p class="text-xs text-slate-500 dark:text-slate-400">Éléments à revoir</p>
+            <p class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">
+              {{ taxReport.sections.reduce((sum, section) => sum + section.items.length, 0) }}
+            </p>
+          </div>
+          <div class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+            <p class="text-xs text-slate-500 dark:text-slate-400">Résidence</p>
+            <p class="mt-2 text-lg font-bold text-slate-900 dark:text-white">
+              {{ taxReport.profile.residenceCountry }}{{ taxReport.profile.residenceRegion ? `-${taxReport.profile.residenceRegion}` : '' }}
+            </p>
+          </div>
+        </div>
+
+        <div v-if="taxReport" class="mt-5 space-y-3">
+          <div
+              v-for="section in taxReport.sections"
+              :key="`${section.jurisdiction}-${section.title}`"
+              class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <h4 class="font-semibold text-slate-900 dark:text-white">
+                [{{ section.jurisdiction }}] {{ section.title }}
+              </h4>
+              <span class="soft-badge">{{ section.severity }}</span>
+            </div>
+            <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <li v-for="item in section.items" :key="`${item.entityType}-${item.entityId}-${item.label}`">
+                <strong>{{ item.label }}</strong>
+                <span v-if="item.amount != null"> · {{ formatMoney(item.amount, item.currency || taxReport.profile.currency) }}</span>
+                <br>
+                {{ item.explanation }}
+                <br>
+                <span class="text-xs text-slate-500 dark:text-slate-400">
+                  À vérifier : {{ item.suggestedForms.join(', ') }} · confiance {{ item.confidence }}
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="!taxReport.sections.length" class="empty-state">
+            Aucun signal fiscal détecté avec les règles configurées.
+          </div>
+        </div>
+
+        <div v-else class="mt-4 empty-state">
+          Crée un profil fiscal pour générer le rapport.
+        </div>
+      </section>
+    </div>
+
+    <section class="mt-6">
+      <div class="panel-header !px-0">
+        <div>
+          <p class="panel-eyebrow">Comptes</p>
+          <h4 class="panel-title">Pays, province et nature fiscale</h4>
+        </div>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="w-full min-w-[960px]">
+          <thead>
+          <tr class="table-head">
+            <th class="table-cell-head text-left">Compte</th>
+            <th class="table-cell-head text-left">Pays</th>
+            <th class="table-cell-head text-left">Région</th>
+            <th class="table-cell-head text-left">Nature fiscale</th>
+            <th class="table-cell-head text-left">Ouverture</th>
+            <th class="table-cell-head text-left">Fermeture</th>
+            <th class="table-cell-head text-right">Action</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr v-for="account in accounts" :key="account.id" class="table-row">
+            <td class="table-cell font-medium">{{ account.name }}</td>
+            <td class="table-cell"><input v-model="accountForms[account.id].institutionCountry" class="field-control" maxlength="12" placeholder="FR / CA / US"></td>
+            <td class="table-cell"><input v-model="accountForms[account.id].institutionRegion" class="field-control" maxlength="12" placeholder="QC"></td>
+            <td class="table-cell">
+              <select v-model="accountForms[account.id].taxReportingType" class="field-control">
+                <option v-for="type in accountTaxReportingTypes" :key="type" :value="type">{{ type }}</option>
+              </select>
+            </td>
+            <td class="table-cell"><input v-model="accountForms[account.id].openedAt" type="date" class="field-control"></td>
+            <td class="table-cell"><input v-model="accountForms[account.id].closedAt" type="date" class="field-control"></td>
+            <td class="table-cell text-right">
+              <button class="ghost-btn" :disabled="savingAccountId === account.id" @click="saveAccountTaxMetadata(account)">
+                {{ savingAccountId === account.id ? '...' : 'Sauver' }}
+              </button>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="mt-6">
+      <div class="panel-header !px-0">
+        <div>
+          <p class="panel-eyebrow">Rentrées d'argent</p>
+          <h4 class="panel-title">Source, retenue à la source et justificatifs</h4>
+        </div>
+      </div>
+
+      <div v-if="incomeTransactionsForSelectedYear.length" class="overflow-x-auto">
+        <table class="w-full min-w-[1180px]">
+          <thead>
+          <tr class="table-head">
+            <th class="table-cell-head text-left">Transaction</th>
+            <th class="table-cell-head text-left">Catégorie fiscale</th>
+            <th class="table-cell-head text-left">Pays source</th>
+            <th class="table-cell-head text-left">Région source</th>
+            <th class="table-cell-head text-left">Traitement</th>
+            <th class="table-cell-head text-left">Impôt retenu</th>
+            <th class="table-cell-head text-left">Devise</th>
+            <th class="table-cell-head text-left">Pays retenue</th>
+            <th class="table-cell-head text-left">Doc</th>
+            <th class="table-cell-head text-right">Action</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr v-for="transaction in incomeTransactionsForSelectedYear" :key="transaction.id" class="table-row">
+            <td class="table-cell">
+              <div class="font-medium">{{ transaction.label }}</div>
+              <div class="text-xs text-slate-500">{{ toDateOnly(transaction.date) }} · {{ formatMoney(Math.abs(transaction.sourceAmount ?? transaction.amount), transaction.sourceCurrency || transaction.account?.currency || 'CAD') }}</div>
+            </td>
+            <td class="table-cell">
+              <select v-model="transactionForms[transaction.id].taxCategory" class="field-control">
+                <option value="">—</option>
+                <option v-for="category in taxIncomeCategories" :key="category" :value="category">{{ category }}</option>
+              </select>
+            </td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxSourceCountry" class="field-control" maxlength="12" placeholder="FR / CA / US"></td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxSourceRegion" class="field-control" maxlength="12" placeholder="QC"></td>
+            <td class="table-cell">
+              <select v-model="transactionForms[transaction.id].taxTreatment" class="field-control">
+                <option v-for="treatment in taxTreatments" :key="treatment" :value="treatment">{{ treatment }}</option>
+              </select>
+            </td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxWithheldAmount" type="number" min="0" step="0.01" class="field-control" placeholder="0.00"></td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxWithheldCurrency" class="field-control" maxlength="6" placeholder="CAD"></td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxWithheldCountry" class="field-control" maxlength="12" placeholder="CA"></td>
+            <td class="table-cell"><input v-model="transactionForms[transaction.id].taxDocumentRef" class="field-control" placeholder="T4/RL-1/IFU..."></td>
+            <td class="table-cell text-right">
+              <button class="ghost-btn" :disabled="savingTransactionId === transaction.id" @click="saveTransactionTaxMetadata(transaction)">
+                {{ savingTransactionId === transaction.id ? '...' : 'Sauver' }}
+              </button>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-else class="empty-state">
+        Aucune rentrée d'argent pour l'année fiscale sélectionnée.
+      </div>
+    </section>
+  </section>
+</template>

--- a/src/composables/useJsonBackup.ts
+++ b/src/composables/useJsonBackup.ts
@@ -6,6 +6,7 @@ import type {
     BudgetTarget,
     Category,
     RecurringTransactionTemplate,
+    TaxProfile,
     Transaction,
 } from '../types/budget'
 import {tr} from '../i18n'
@@ -18,6 +19,7 @@ interface UseJsonBackupOptions {
     budgetTargets: Ref<BudgetTarget[]>
     recurringTemplates: Ref<RecurringTransactionTemplate[]>
     transactions: Ref<Transaction[]>
+    taxProfiles?: Ref<TaxProfile[]>
     refreshAllData: () => Promise<unknown>
     showNotice: (type: 'success' | 'error', text: string) => void
 }
@@ -46,6 +48,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
             options.budgetTargets.value,
             options.recurringTemplates.value,
             options.transactions.value,
+            options.taxProfiles?.value || [],
         )
 
         const result = await window.file.saveText({

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -7,11 +7,14 @@ declare module '*.vue' {
 }
 
 type AccountTypeDto = 'CASH' | 'BANK' | 'SAVINGS' | 'CREDIT' | 'INVESTMENT' | 'OTHER'
+type AccountTaxReportingTypeDto = 'STANDARD' | 'BANK' | 'CASH' | 'BROKERAGE' | 'CRYPTO' | 'LIFE_INSURANCE' | 'RETIREMENT' | 'LOAN' | 'OTHER'
 type TransactionKindDto = 'INCOME' | 'EXPENSE' | 'TRANSFER'
 type ConversionModeDto = 'NONE' | 'MANUAL' | 'AUTOMATIC'
 type TransferDirectionDto = 'OUT' | 'IN'
 type BudgetPeriodDto = 'MONTHLY' | 'YEARLY' | 'CUSTOM'
 type RecurringFrequencyDto = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY'
+type TaxIncomeCategoryDto = 'EMPLOYMENT' | 'BUSINESS' | 'INTEREST' | 'DIVIDEND' | 'CAPITAL_GAIN' | 'RENTAL' | 'PENSION' | 'BENEFIT' | 'GIFT' | 'REFUND' | 'TRANSFER' | 'OTHER'
+type TaxTreatmentDto = 'UNKNOWN' | 'NOT_TAXABLE' | 'TAXABLE_NO_WITHHOLDING' | 'TAX_WITHHELD_AT_SOURCE' | 'FOREIGN_TAX_CREDIT_CANDIDATE' | 'TREATY_EXEMPT_CANDIDATE' | 'REVIEW_REQUIRED'
 
 interface AccountDto {
     id: number
@@ -19,6 +22,11 @@ interface AccountDto {
     type: AccountTypeDto
     currency: string
     description: string | null
+    institutionCountry: string | null
+    institutionRegion: string | null
+    taxReportingType: AccountTaxReportingTypeDto
+    openedAt: string | null
+    closedAt: string | null
     createdAt: string
     updatedAt: string
 }
@@ -46,6 +54,14 @@ interface TransactionDto {
     kind: TransactionKindDto
     date: string
     note: string | null
+    taxCategory: TaxIncomeCategoryDto | null
+    taxSourceCountry: string | null
+    taxSourceRegion: string | null
+    taxTreatment: TaxTreatmentDto
+    taxWithheldAmount: number | null
+    taxWithheldCurrency: string | null
+    taxWithheldCountry: string | null
+    taxDocumentRef: string | null
     accountId: number
     categoryId: number | null
     transferGroup?: string | null
@@ -56,6 +72,16 @@ interface TransactionDto {
     account?: AccountDto
     category?: CategoryDto | null
     transferPeerAccount?: AccountDto | null
+}
+
+interface TaxProfileDto {
+    id: number
+    year: number
+    residenceCountry: string
+    residenceRegion: string | null
+    currency: string
+    createdAt: string
+    updatedAt: string
 }
 
 interface BudgetTargetDto {
@@ -279,6 +305,43 @@ interface Window {
                 asOfDate?: string
                 templateId?: number
             }) => Promise<RecurringGenerationResult>
+        }
+
+        taxProfile: {
+            list: () => Promise<TaxProfileDto[]>
+            create: (data: {
+                year: number
+                residenceCountry: string
+                residenceRegion?: string | null
+                currency?: string
+            }) => Promise<TaxProfileDto>
+            update: (id: number, data: {
+                year: number
+                residenceCountry: string
+                residenceRegion?: string | null
+                currency?: string
+            }) => Promise<TaxProfileDto>
+            delete: (id: number) => Promise<TaxProfileDto>
+        }
+
+        taxMetadata: {
+            updateAccount: (id: number, data: {
+                institutionCountry?: string | null
+                institutionRegion?: string | null
+                taxReportingType?: AccountTaxReportingTypeDto
+                openedAt?: string | null
+                closedAt?: string | null
+            }) => Promise<AccountDto>
+            updateTransaction: (id: number, data: {
+                taxCategory?: TaxIncomeCategoryDto | null
+                taxSourceCountry?: string | null
+                taxSourceRegion?: string | null
+                taxTreatment?: TaxTreatmentDto
+                taxWithheldAmount?: number | null
+                taxWithheldCurrency?: string | null
+                taxWithheldCountry?: string | null
+                taxDocumentRef?: string | null
+            }) => Promise<TransactionDto>
         }
     }
 

--- a/src/test/composables/useJsonBackup.smoke.test.ts
+++ b/src/test/composables/useJsonBackup.smoke.test.ts
@@ -48,9 +48,20 @@ describe('useJsonBackup smoke', () => {
         }
     })
 
-    it('exports a version 3 backup and opens a valid restore preview', async () => {
+    it('exports a version 4 backup and opens a valid restore preview', async () => {
         const accounts = ref([
-            {id: 1, name: 'Main', type: 'BANK', currency: 'CAD', description: null},
+            {
+                id: 1,
+                name: 'Main',
+                type: 'BANK',
+                currency: 'CAD',
+                description: null,
+                institutionCountry: 'CA',
+                institutionRegion: 'QC',
+                taxReportingType: 'BANK',
+                openedAt: null,
+                closedAt: null,
+            },
         ] as any)
 
         const categories = ref([
@@ -74,6 +85,14 @@ describe('useJsonBackup smoke', () => {
                 kind: 'EXPENSE',
                 date: '2026-04-10',
                 note: null,
+                taxCategory: null,
+                taxSourceCountry: null,
+                taxSourceRegion: null,
+                taxTreatment: 'UNKNOWN',
+                taxWithheldAmount: null,
+                taxWithheldCurrency: null,
+                taxWithheldCountry: null,
+                taxDocumentRef: null,
                 accountId: 1,
                 categoryId: 10,
                 transferGroup: null,
@@ -100,7 +119,9 @@ describe('useJsonBackup smoke', () => {
 
         const exportedContent = saveTextMock.mock.calls[0][0].content
         expect(exportedContent).toContain('"kind": "budget-backup"')
-        expect(exportedContent).toContain('"version": 3')
+        expect(exportedContent).toContain('"version": 4')
+        expect(exportedContent).toContain('"institutionCountry": "CA"')
+        expect(exportedContent).toContain('"taxProfiles": []')
 
         openTextMock.mockResolvedValue({
             canceled: false,

--- a/src/test/utils/jsonBackup.test.ts
+++ b/src/test/utils/jsonBackup.test.ts
@@ -2,9 +2,20 @@ import {describe, expect, it} from 'vitest'
 import {createBudgetBackupSnapshot, parseBudgetBackup, serializeBudgetBackup} from '../../utils/jsonBackup'
 
 describe('json backup utils', () => {
-    it('creates and parses a valid snapshot with budgets, recurring templates and transfer metadata', () => {
+    it('creates and parses a valid v4 snapshot with budgets, recurring templates, transfer metadata and tax metadata', () => {
         const snapshot = createBudgetBackupSnapshot(
-            [{id: 1, name: 'Main', type: 'BANK', currency: 'CAD', description: null}],
+            [{
+                id: 1,
+                name: 'Main',
+                type: 'BANK',
+                currency: 'CAD',
+                description: null,
+                institutionCountry: 'CA',
+                institutionRegion: 'QC',
+                taxReportingType: 'BANK',
+                openedAt: '2026-01-01T00:00:00.000Z',
+                closedAt: null,
+            }],
             [{id: 2, name: 'Food', kind: 'EXPENSE', color: '#ff00aa', description: null}],
             [{
                 id: 10,
@@ -51,11 +62,26 @@ describe('json backup utils', () => {
                 kind: 'TRANSFER',
                 date: '2026-04-20T00:00:00.000Z',
                 note: null,
+                taxCategory: 'TRANSFER',
+                taxSourceCountry: 'CA',
+                taxSourceRegion: 'QC',
+                taxTreatment: 'NOT_TAXABLE',
+                taxWithheldAmount: null,
+                taxWithheldCurrency: null,
+                taxWithheldCountry: null,
+                taxDocumentRef: 'internal-transfer-note',
                 accountId: 1,
                 categoryId: null,
                 transferGroup: 'grp-1',
                 transferDirection: 'OUT',
                 transferPeerAccountId: 99,
+            }],
+            [{
+                id: 50,
+                year: 2026,
+                residenceCountry: 'CA',
+                residenceRegion: 'QC',
+                currency: 'CAD',
             }],
         )
 
@@ -63,8 +89,11 @@ describe('json backup utils', () => {
         const parsed = parseBudgetBackup(serialized)
 
         expect(parsed.kind).toBe('budget-backup')
-        expect(parsed.version).toBe(3)
+        expect(parsed.version).toBe(4)
         expect(parsed.data.accounts).toHaveLength(1)
+        expect(parsed.data.accounts[0].institutionCountry).toBe('CA')
+        expect(parsed.data.accounts[0].institutionRegion).toBe('QC')
+        expect(parsed.data.accounts[0].taxReportingType).toBe('BANK')
         expect(parsed.data.categories).toHaveLength(1)
         expect(parsed.data.budgetTargets).toHaveLength(1)
         expect(parsed.data.recurringTemplates).toHaveLength(1)
@@ -72,6 +101,10 @@ describe('json backup utils', () => {
         expect(parsed.data.transactions[0].transferGroup).toBe('grp-1')
         expect(parsed.data.transactions[0].transferDirection).toBe('OUT')
         expect(parsed.data.transactions[0].transferPeerAccountId).toBe(99)
+        expect(parsed.data.transactions[0].taxTreatment).toBe('NOT_TAXABLE')
+        expect(parsed.data.transactions[0].taxDocumentRef).toBe('internal-transfer-note')
+        expect(parsed.data.taxProfiles).toHaveLength(1)
+        expect(parsed.data.taxProfiles?.[0].residenceRegion).toBe('QC')
     })
 
     it('accepts legacy version 2 snapshots', () => {
@@ -89,6 +122,23 @@ describe('json backup utils', () => {
         }))
 
         expect(parsed.version).toBe(2)
+    })
+
+    it('accepts legacy version 3 snapshots', () => {
+        const parsed = parseBudgetBackup(JSON.stringify({
+            kind: 'budget-backup',
+            version: 3,
+            exportedAt: '2026-04-20T00:00:00.000Z',
+            data: {
+                accounts: [],
+                categories: [],
+                budgetTargets: [],
+                recurringTemplates: [],
+                transactions: [],
+            },
+        }))
+
+        expect(parsed.version).toBe(3)
     })
 
     it('rejects invalid snapshot', () => {

--- a/src/types/budget.ts
+++ b/src/types/budget.ts
@@ -4,12 +4,18 @@ export type EntityType = 'transaction' | 'account' | 'category'
 export type PanelMode = 'create' | 'edit'
 export type TransactionKind = 'INCOME' | 'EXPENSE' | 'TRANSFER'
 export type AccountType = 'CASH' | 'BANK' | 'SAVINGS' | 'CREDIT' | 'INVESTMENT' | 'OTHER'
+export type AccountTaxReportingType = 'STANDARD' | 'BANK' | 'CASH' | 'BROKERAGE' | 'CRYPTO' | 'LIFE_INSURANCE' | 'RETIREMENT' | 'LOAN' | 'OTHER'
 export type ConversionMode = 'NONE' | 'MANUAL' | 'AUTOMATIC'
 export type TransferDirection = 'OUT' | 'IN'
 export type ReportPreset = 'THIS_MONTH' | 'LAST_30_DAYS' | 'THIS_YEAR' | 'ALL' | 'CUSTOM'
 export type BudgetPeriod = 'MONTHLY' | 'YEARLY' | 'CUSTOM'
 export type BudgetStatus = 'UNDER' | 'NEAR' | 'OVER'
 export type RecurringFrequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY'
+export type TaxIncomeCategory = 'EMPLOYMENT' | 'BUSINESS' | 'INTEREST' | 'DIVIDEND' | 'CAPITAL_GAIN' | 'RENTAL' | 'PENSION' | 'BENEFIT' | 'GIFT' | 'REFUND' | 'TRANSFER' | 'OTHER'
+export type TaxTreatment = 'UNKNOWN' | 'NOT_TAXABLE' | 'TAXABLE_NO_WITHHOLDING' | 'TAX_WITHHELD_AT_SOURCE' | 'FOREIGN_TAX_CREDIT_CANDIDATE' | 'TREATY_EXEMPT_CANDIDATE' | 'REVIEW_REQUIRED'
+export type TaxJurisdiction = 'FR' | 'CA' | 'QC'
+export type TaxReportSeverity = 'info' | 'warning' | 'review'
+export type TaxReportConfidence = 'low' | 'medium' | 'high'
 
 export interface Account {
     id: number
@@ -17,6 +23,11 @@ export interface Account {
     type: AccountType
     currency: string
     description: string | null
+    institutionCountry?: string | null
+    institutionRegion?: string | null
+    taxReportingType?: AccountTaxReportingType
+    openedAt?: string | null
+    closedAt?: string | null
 }
 
 export interface Category {
@@ -40,6 +51,14 @@ export interface Transaction {
     kind: TransactionKind
     date: string
     note: string | null
+    taxCategory?: TaxIncomeCategory | null
+    taxSourceCountry?: string | null
+    taxSourceRegion?: string | null
+    taxTreatment?: TaxTreatment
+    taxWithheldAmount?: number | null
+    taxWithheldCurrency?: string | null
+    taxWithheldCountry?: string | null
+    taxDocumentRef?: string | null
     accountId: number
     categoryId: number | null
     transferGroup?: string | null
@@ -48,6 +67,39 @@ export interface Transaction {
     account?: Account | null
     category?: Category | null
     transferPeerAccount?: Account | null
+}
+
+export interface TaxProfile {
+    id: number
+    year: number
+    residenceCountry: string
+    residenceRegion: string | null
+    currency: string
+}
+
+export interface TaxReportItem {
+    entityType: 'account' | 'transaction' | 'aggregate'
+    entityId?: number
+    label: string
+    amount?: number
+    currency?: string
+    explanation: string
+    suggestedForms: string[]
+    confidence: TaxReportConfidence
+}
+
+export interface TaxReportSection {
+    jurisdiction: TaxJurisdiction
+    title: string
+    severity: TaxReportSeverity
+    items: TaxReportItem[]
+}
+
+export interface TaxReport {
+    profile: TaxProfile
+    generatedAt: string
+    sections: TaxReportSection[]
+    disclaimer: string
 }
 
 export interface BudgetTarget {
@@ -278,6 +330,11 @@ export interface BudgetBackupAccount {
     type: AccountType
     currency: string
     description: string | null
+    institutionCountry?: string | null
+    institutionRegion?: string | null
+    taxReportingType?: AccountTaxReportingType
+    openedAt?: string | null
+    closedAt?: string | null
 }
 
 export interface BudgetBackupCategory {
@@ -335,6 +392,14 @@ export interface BudgetBackupTransaction {
     kind: TransactionKind
     date: string
     note: string | null
+    taxCategory?: TaxIncomeCategory | null
+    taxSourceCountry?: string | null
+    taxSourceRegion?: string | null
+    taxTreatment?: TaxTreatment
+    taxWithheldAmount?: number | null
+    taxWithheldCurrency?: string | null
+    taxWithheldCountry?: string | null
+    taxDocumentRef?: string | null
     accountId: number
     categoryId: number | null
     transferGroup?: string | null
@@ -342,9 +407,17 @@ export interface BudgetBackupTransaction {
     transferPeerAccountId?: number | null
 }
 
+export interface BudgetBackupTaxProfile {
+    id: number
+    year: number
+    residenceCountry: string
+    residenceRegion: string | null
+    currency: string
+}
+
 export interface BudgetBackupSnapshot {
     kind: 'budget-backup'
-    version: 2 | 3
+    version: 2 | 3 | 4
     exportedAt: string
     data: {
         accounts: BudgetBackupAccount[]
@@ -352,5 +425,6 @@ export interface BudgetBackupSnapshot {
         budgetTargets: BudgetBackupBudgetTarget[]
         recurringTemplates: BudgetBackupRecurringTransactionTemplate[]
         transactions: BudgetBackupTransaction[]
+        taxProfiles?: BudgetBackupTaxProfile[]
     }
 }

--- a/src/utils/jsonBackup.ts
+++ b/src/utils/jsonBackup.ts
@@ -4,6 +4,7 @@ import type {
     BudgetTarget,
     Category,
     RecurringTransactionTemplate,
+    TaxProfile,
     Transaction,
 } from '../types/budget'
 
@@ -13,10 +14,11 @@ export function createBudgetBackupSnapshot(
     budgetTargets: BudgetTarget[],
     recurringTemplates: RecurringTransactionTemplate[],
     transactions: Transaction[],
+    taxProfiles: TaxProfile[] = [],
 ): BudgetBackupSnapshot {
     return {
         kind: 'budget-backup',
-        version: 3,
+        version: 4,
         exportedAt: new Date().toISOString(),
         data: {
             accounts: accounts.map((account) => ({
@@ -25,6 +27,11 @@ export function createBudgetBackupSnapshot(
                 type: account.type,
                 currency: account.currency,
                 description: account.description,
+                institutionCountry: account.institutionCountry ?? null,
+                institutionRegion: account.institutionRegion ?? null,
+                taxReportingType: account.taxReportingType ?? 'STANDARD',
+                openedAt: account.openedAt ? new Date(account.openedAt).toISOString() : null,
+                closedAt: account.closedAt ? new Date(account.closedAt).toISOString() : null,
             })),
             categories: categories.map((category) => ({
                 id: category.id,
@@ -78,11 +85,26 @@ export function createBudgetBackupSnapshot(
                 kind: transaction.kind,
                 date: new Date(transaction.date).toISOString(),
                 note: transaction.note,
+                taxCategory: transaction.taxCategory ?? null,
+                taxSourceCountry: transaction.taxSourceCountry ?? null,
+                taxSourceRegion: transaction.taxSourceRegion ?? null,
+                taxTreatment: transaction.taxTreatment ?? 'UNKNOWN',
+                taxWithheldAmount: transaction.taxWithheldAmount ?? null,
+                taxWithheldCurrency: transaction.taxWithheldCurrency ?? null,
+                taxWithheldCountry: transaction.taxWithheldCountry ?? null,
+                taxDocumentRef: transaction.taxDocumentRef ?? null,
                 accountId: transaction.accountId,
                 categoryId: transaction.categoryId,
                 transferGroup: transaction.transferGroup ?? null,
                 transferDirection: transaction.transferDirection ?? null,
                 transferPeerAccountId: transaction.transferPeerAccountId ?? null,
+            })),
+            taxProfiles: taxProfiles.map((profile) => ({
+                id: profile.id,
+                year: profile.year,
+                residenceCountry: profile.residenceCountry,
+                residenceRegion: profile.residenceRegion,
+                currency: profile.currency,
             })),
         },
     }
@@ -98,13 +120,14 @@ export function parseBudgetBackup(content: string): BudgetBackupSnapshot {
     if (
         !parsed ||
         parsed.kind !== 'budget-backup' ||
-        ![2, 3].includes(parsed.version) ||
+        ![2, 3, 4].includes(parsed.version) ||
         !parsed.data ||
         !Array.isArray(parsed.data.accounts) ||
         !Array.isArray(parsed.data.categories) ||
         !Array.isArray(parsed.data.budgetTargets) ||
         !Array.isArray(parsed.data.recurringTemplates) ||
-        !Array.isArray(parsed.data.transactions)
+        !Array.isArray(parsed.data.transactions) ||
+        (parsed.data.taxProfiles != null && !Array.isArray(parsed.data.taxProfiles))
     ) {
         throw new Error('Le fichier JSON ne correspond pas à un backup budget valide.')
     }

--- a/src/utils/taxReport.test.ts
+++ b/src/utils/taxReport.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from 'vitest'
+import type {Account, TaxProfile, Transaction} from '../types/budget'
+import {buildTaxReport, taxReportToMarkdown} from './taxReport'
+
+function account(overrides: Partial<Account>): Account {
+    return {
+        id: 1,
+        name: 'Compte test',
+        type: 'BANK',
+        currency: 'EUR',
+        description: null,
+        taxReportingType: 'STANDARD',
+        ...overrides,
+    }
+}
+
+function transaction(overrides: Partial<Transaction>): Transaction {
+    const baseAccount = account({id: 1, name: 'Compte France'})
+
+    return {
+        id: 1,
+        label: 'Revenu test',
+        amount: 100,
+        sourceAmount: 100,
+        sourceCurrency: 'EUR',
+        conversionMode: 'NONE',
+        exchangeRate: 1,
+        exchangeProvider: 'ACCOUNT',
+        exchangeDate: '2026-01-15T00:00:00.000Z',
+        kind: 'INCOME',
+        date: '2026-01-15',
+        note: null,
+        taxTreatment: 'UNKNOWN',
+        accountId: baseAccount.id,
+        categoryId: null,
+        account: baseAccount,
+        category: null,
+        ...overrides,
+    }
+}
+
+const franceProfile: TaxProfile = {
+    id: 1,
+    year: 2026,
+    residenceCountry: 'FR',
+    residenceRegion: null,
+    currency: 'EUR',
+}
+
+const quebecProfile: TaxProfile = {
+    id: 2,
+    year: 2026,
+    residenceCountry: 'CA',
+    residenceRegion: 'QC',
+    currency: 'CAD',
+}
+
+describe('buildTaxReport', () => {
+    it('flags foreign accounts and foreign income for a French tax profile', () => {
+        const foreignAccount = account({
+            id: 10,
+            name: 'Courtier Canada',
+            currency: 'CAD',
+            institutionCountry: 'CA',
+            taxReportingType: 'BROKERAGE',
+        })
+
+        const income = transaction({
+            id: 20,
+            label: 'Dividendes Canada',
+            amount: 140,
+            sourceAmount: 100,
+            sourceCurrency: 'CAD',
+            taxCategory: 'DIVIDEND',
+            taxSourceCountry: 'CA',
+            taxWithheldAmount: 15,
+            taxWithheldCurrency: 'CAD',
+            taxWithheldCountry: 'CA',
+            accountId: foreignAccount.id,
+            account: foreignAccount,
+        })
+
+        const report = buildTaxReport(franceProfile, [foreignAccount], [income])
+
+        expect(report.sections.map((section) => section.title)).toEqual([
+            'Comptes étrangers potentiellement déclarables',
+            'Revenus étrangers à vérifier',
+            'Impôt étranger retenu / crédit potentiel',
+        ])
+        expect(report.sections[0].items[0].suggestedForms).toContain('3916')
+        expect(report.sections[1].items[0].suggestedForms).toContain('2047')
+        expect(report.sections[2].items[0].amount).toBe(15)
+    })
+
+    it('ignores income outside the selected tax year', () => {
+        const income = transaction({
+            date: '2025-12-31',
+            taxSourceCountry: 'CA',
+            taxWithheldAmount: 10,
+            taxWithheldCurrency: 'CAD',
+            taxWithheldCountry: 'CA',
+        })
+
+        const report = buildTaxReport(franceProfile, [], [income])
+
+        expect(report.sections).toEqual([])
+    })
+
+    it('generates federal and Quebec sections for a Quebec resident', () => {
+        const usAccount = account({
+            id: 30,
+            name: 'Broker US',
+            currency: 'USD',
+            institutionCountry: 'US',
+            taxReportingType: 'BROKERAGE',
+        })
+
+        const usIncome = transaction({
+            id: 31,
+            label: 'Intérêts US',
+            amount: 136,
+            sourceAmount: 100,
+            sourceCurrency: 'USD',
+            taxCategory: 'INTEREST',
+            taxSourceCountry: 'US',
+            taxWithheldAmount: 12,
+            taxWithheldCurrency: 'USD',
+            taxWithheldCountry: 'US',
+            accountId: usAccount.id,
+            account: usAccount,
+        })
+
+        const report = buildTaxReport(quebecProfile, [usAccount], [usIncome])
+
+        expect(report.sections.some((section) => section.jurisdiction === 'CA')).toBe(true)
+        expect(report.sections.some((section) => section.jurisdiction === 'QC')).toBe(true)
+        expect(report.sections.flatMap((section) => section.items).some((item) => item.suggestedForms.includes('T1135'))).toBe(true)
+    })
+})
+
+describe('taxReportToMarkdown', () => {
+    it('serializes sections and disclaimer', () => {
+        const report = buildTaxReport(franceProfile, [
+            account({id: 99, name: 'Banque Québec', institutionCountry: 'CA'}),
+        ], [])
+
+        const markdown = taxReportToMarkdown(report)
+
+        expect(markdown).toContain('# Rapport fiscal 2026')
+        expect(markdown).toContain("aide à l'inventaire fiscal")
+        expect(markdown).toContain('Banque Québec')
+    })
+})

--- a/src/utils/taxReport.ts
+++ b/src/utils/taxReport.ts
@@ -1,0 +1,290 @@
+import type {
+    Account,
+    TaxProfile,
+    TaxReport,
+    TaxReportItem,
+    TaxReportSection,
+    Transaction,
+} from '../types/budget'
+import {toUtcDate} from './date'
+
+interface TaxRuleContext {
+    profile: TaxProfile
+    accounts: Account[]
+    transactions: Transaction[]
+}
+
+const TAX_DISCLAIMER = [
+    "Ce rapport est une aide à l'inventaire fiscal, pas un conseil fiscal ni un calcul d'impôt.",
+    'Il signale les comptes, revenus et retenues à vérifier avec les formulaires probables.',
+    'Les seuils, conventions fiscales, crédits et cases exactes doivent être confirmés avec les administrations ou un professionnel.',
+].join(' ')
+
+function normalizeCode(value: string | null | undefined) {
+    const trimmed = value?.trim().toUpperCase()
+    return trimmed || null
+}
+
+function taxYearOf(transaction: Transaction) {
+    return toUtcDate(transaction.date).getUTCFullYear()
+}
+
+function isIncomeInProfileYear(transaction: Transaction, profile: TaxProfile) {
+    return transaction.kind === 'INCOME' && taxYearOf(transaction) === profile.year
+}
+
+function amountOf(transaction: Transaction) {
+    return Math.abs(transaction.sourceAmount ?? transaction.amount)
+}
+
+function currencyOf(transaction: Transaction) {
+    return normalizeCode(transaction.sourceCurrency) || normalizeCode(transaction.account?.currency) || 'CAD'
+}
+
+function accountCountry(account: Account | null | undefined) {
+    return normalizeCode(account?.institutionCountry)
+}
+
+function transactionSourceCountry(transaction: Transaction) {
+    return normalizeCode(transaction.taxSourceCountry) || accountCountry(transaction.account)
+}
+
+function transactionSourceRegion(transaction: Transaction) {
+    return normalizeCode(transaction.taxSourceRegion) || normalizeCode(transaction.account?.institutionRegion)
+}
+
+function isForeignCountry(country: string | null | undefined, residenceCountry: string) {
+    const normalized = normalizeCode(country)
+    return Boolean(normalized && normalized !== normalizeCode(residenceCountry))
+}
+
+function hasForeignTaxWithheld(transaction: Transaction, residenceCountry: string) {
+    const withheldAmount = transaction.taxWithheldAmount ?? 0
+    if (withheldAmount <= 0) return false
+
+    const withheldCountry = normalizeCode(transaction.taxWithheldCountry)
+    return Boolean(withheldCountry && withheldCountry !== normalizeCode(residenceCountry))
+}
+
+function section(
+    jurisdiction: TaxReportSection['jurisdiction'],
+    title: string,
+    severity: TaxReportSection['severity'],
+    items: TaxReportItem[],
+): TaxReportSection | null {
+    if (!items.length) return null
+    return {
+        jurisdiction,
+        title,
+        severity,
+        items,
+    }
+}
+
+function franceRules(context: TaxRuleContext) {
+    const {accounts, transactions, profile} = context
+    const incomeTransactions = transactions.filter((transaction) => isIncomeInProfileYear(transaction, profile))
+
+    const foreignAccounts = accounts
+        .filter((account) => isForeignCountry(account.institutionCountry, 'FR'))
+        .map<TaxReportItem>((account) => ({
+            entityType: 'account',
+            entityId: account.id,
+            label: account.name,
+            explanation: `Compte situé hors de France (${account.institutionCountry}). À vérifier comme compte, actif numérique, contrat ou placement étranger déclarable selon sa nature.`,
+            suggestedForms: ['3916', '3916-bis'],
+            confidence: account.institutionCountry ? 'high' : 'medium',
+        }))
+
+    const foreignIncome = incomeTransactions
+        .filter((transaction) => isForeignCountry(transactionSourceCountry(transaction), 'FR'))
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: amountOf(transaction),
+            currency: currencyOf(transaction),
+            explanation: `Revenu de source étrangère détecté (${transactionSourceCountry(transaction)}). À vérifier pour déclaration des revenus étrangers puis report sur la déclaration principale.`,
+            suggestedForms: ['2047', '2042'],
+            confidence: transaction.taxSourceCountry ? 'high' : 'medium',
+        }))
+
+    const foreignTaxCredits = incomeTransactions
+        .filter((transaction) => hasForeignTaxWithheld(transaction, 'FR'))
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: transaction.taxWithheldAmount ?? undefined,
+            currency: normalizeCode(transaction.taxWithheldCurrency) || currencyOf(transaction),
+            explanation: `Impôt retenu hors de France (${transaction.taxWithheldCountry}). Crédit d'impôt ou mécanisme conventionnel potentiel à vérifier.`,
+            suggestedForms: ['2047', '2042'],
+            confidence: 'medium',
+        }))
+
+    return [
+        section('FR', 'Comptes étrangers potentiellement déclarables', 'review', foreignAccounts),
+        section('FR', 'Revenus étrangers à vérifier', 'review', foreignIncome),
+        section('FR', 'Impôt étranger retenu / crédit potentiel', 'warning', foreignTaxCredits),
+    ].filter(Boolean) as TaxReportSection[]
+}
+
+function canadaFederalRules(context: TaxRuleContext) {
+    const {accounts, transactions, profile} = context
+    const incomeTransactions = transactions.filter((transaction) => isIncomeInProfileYear(transaction, profile))
+
+    const foreignPropertyAccounts = accounts
+        .filter((account) => isForeignCountry(account.institutionCountry, 'CA'))
+        .map<TaxReportItem>((account) => ({
+            entityType: 'account',
+            entityId: account.id,
+            label: account.name,
+            explanation: `Compte ou actif situé hors Canada (${account.institutionCountry}). À vérifier pour le formulaire T1135 si les biens étrangers déterminés dépassent le seuil applicable.`,
+            suggestedForms: ['T1135'],
+            confidence: ['BROKERAGE', 'CRYPTO', 'INVESTMENT', 'LIFE_INSURANCE'].includes(account.taxReportingType || '') ? 'high' : 'medium',
+        }))
+
+    const foreignIncome = incomeTransactions
+        .filter((transaction) => isForeignCountry(transactionSourceCountry(transaction), 'CA'))
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: amountOf(transaction),
+            currency: currencyOf(transaction),
+            explanation: `Revenu de source étrangère détecté (${transactionSourceCountry(transaction)}). À déclarer en dollars canadiens et à vérifier pour crédit fédéral d'impôt étranger si un impôt étranger a été payé.`,
+            suggestedForms: ['T1', 'T2209', 'line 40500'],
+            confidence: transaction.taxSourceCountry ? 'high' : 'medium',
+        }))
+
+    const foreignTaxCredits = incomeTransactions
+        .filter((transaction) => hasForeignTaxWithheld(transaction, 'CA'))
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: transaction.taxWithheldAmount ?? undefined,
+            currency: normalizeCode(transaction.taxWithheldCurrency) || currencyOf(transaction),
+            explanation: `Impôt retenu hors Canada (${transaction.taxWithheldCountry}). Crédit fédéral d'impôt étranger potentiel à vérifier.`,
+            suggestedForms: ['T2209', 'line 40500'],
+            confidence: 'medium',
+        }))
+
+    return [
+        section('CA', 'Biens étrangers déterminés à vérifier', 'review', foreignPropertyAccounts),
+        section('CA', 'Revenus étrangers fédéraux à vérifier', 'review', foreignIncome),
+        section('CA', "Crédit fédéral d'impôt étranger potentiel", 'warning', foreignTaxCredits),
+    ].filter(Boolean) as TaxReportSection[]
+}
+
+function quebecRules(context: TaxRuleContext) {
+    const {transactions, profile} = context
+    const incomeTransactions = transactions.filter((transaction) => isIncomeInProfileYear(transaction, profile))
+
+    const outsideQuebecIncome = incomeTransactions
+        .filter((transaction) => {
+            const country = transactionSourceCountry(transaction)
+            const region = transactionSourceRegion(transaction)
+            return isForeignCountry(country, 'CA') || (country === 'CA' && Boolean(region && region !== 'QC'))
+        })
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: amountOf(transaction),
+            currency: currencyOf(transaction),
+            explanation: `Revenu gagné hors Québec détecté (${transactionSourceCountry(transaction) || 'pays inconnu'}${transactionSourceRegion(transaction) ? `-${transactionSourceRegion(transaction)}` : ''}). À vérifier dans la déclaration Québec.`,
+            suggestedForms: ['TP-1', 'Annexe E'],
+            confidence: transaction.taxSourceCountry || transaction.taxSourceRegion ? 'high' : 'medium',
+        }))
+
+    const outsideQuebecTaxWithheld = incomeTransactions
+        .filter((transaction) => {
+            const amount = transaction.taxWithheldAmount ?? 0
+            if (amount <= 0) return false
+            const country = normalizeCode(transaction.taxWithheldCountry)
+            const region = normalizeCode(transaction.taxSourceRegion)
+            return Boolean(country && country !== 'CA') || (country === 'CA' && Boolean(region && region !== 'QC'))
+        })
+        .map<TaxReportItem>((transaction) => ({
+            entityType: 'transaction',
+            entityId: transaction.id,
+            label: transaction.label,
+            amount: transaction.taxWithheldAmount ?? undefined,
+            currency: normalizeCode(transaction.taxWithheldCurrency) || currencyOf(transaction),
+            explanation: `Impôt retenu hors Québec (${transaction.taxWithheldCountry || 'juridiction inconnue'}). Crédit Québec ou transfert d'impôt d'une autre province potentiellement applicable.`,
+            suggestedForms: ['TP-772-V', 'ligne 409', 'ligne 454'],
+            confidence: 'medium',
+        }))
+
+    return [
+        section('QC', 'Revenus hors Québec à vérifier', 'review', outsideQuebecIncome),
+        section('QC', "Crédit Québec ou transfert d'impôt potentiel", 'warning', outsideQuebecTaxWithheld),
+    ].filter(Boolean) as TaxReportSection[]
+}
+
+export function buildTaxReport(
+    profile: TaxProfile,
+    accounts: Account[],
+    transactions: Transaction[],
+): TaxReport {
+    const residenceCountry = normalizeCode(profile.residenceCountry)
+    const residenceRegion = normalizeCode(profile.residenceRegion)
+    const context: TaxRuleContext = {profile, accounts, transactions}
+
+    const sections: TaxReportSection[] = []
+
+    if (residenceCountry === 'FR') {
+        sections.push(...franceRules(context))
+    }
+
+    if (residenceCountry === 'CA') {
+        sections.push(...canadaFederalRules(context))
+
+        if (residenceRegion === 'QC') {
+            sections.push(...quebecRules(context))
+        }
+    }
+
+    return {
+        profile,
+        generatedAt: new Date().toISOString(),
+        sections,
+        disclaimer: TAX_DISCLAIMER,
+    }
+}
+
+export function taxReportToMarkdown(report: TaxReport) {
+    const lines = [
+        `# Rapport fiscal ${report.profile.year}`,
+        '',
+        `Résidence fiscale : ${report.profile.residenceCountry}${report.profile.residenceRegion ? `-${report.profile.residenceRegion}` : ''}`,
+        `Devise de déclaration : ${report.profile.currency}`,
+        '',
+        `> ${report.disclaimer}`,
+        '',
+    ]
+
+    if (!report.sections.length) {
+        lines.push('Aucun signal fiscal détecté avec les règles actuellement configurées.', '')
+        return `${lines.join('\n')}\n`
+    }
+
+    for (const section of report.sections) {
+        lines.push(`## [${section.jurisdiction}] ${section.title}`)
+        lines.push(`Sévérité : ${section.severity}`)
+        lines.push('')
+
+        for (const item of section.items) {
+            const amount = item.amount == null ? '' : ` — ${item.amount.toFixed(2)} ${item.currency || report.profile.currency}`
+            lines.push(`- ${item.label}${amount}`)
+            lines.push(`  - ${item.explanation}`)
+            lines.push(`  - Formulaires / lignes à vérifier : ${item.suggestedForms.join(', ')}`)
+            lines.push(`  - Confiance : ${item.confidence}`)
+        }
+
+        lines.push('')
+    }
+
+    return `${lines.join('\n')}\n`
+}


### PR DESCRIPTION
## Summary

Adds the foundation for a conservative tax-reporting helper focused on France, Canada federal and Québec.

Implemented in this branch:

- Prisma schema fields for account jurisdiction and tax reporting type
- Prisma schema fields for income tax metadata and withholding details
- Annual `TaxProfile` model
- Electron IPC handlers and preload APIs for tax profiles and tax metadata
- TypeScript tax report rule engine for France, Canada federal and Québec
- Markdown tax report serialization
- Unit tests for the tax report engine
- Draft `TaxReportPanel.vue` component for profile creation, metadata editing and Markdown export
- JSON backup snapshot format upgraded to v4 with tax fields support
- Documentation of the tax reporting strategy and boundaries

## Important boundaries

This is intentionally not a tax calculator. The report uses conservative wording such as “to verify” and “review required”; it does not compute final tax liability or claim to provide legal/tax advice.

## Known follow-ups before merge

- The branch is currently behind `master` and should be rebased or updated before final review.
- `TaxReportPanel.vue` has been added but is not wired into `ReportsSection.vue` / `App.vue` yet.
- JSON backup utilities support v4 tax fields, but the app-level backup/restore flow still needs to pass tax profiles and restore metadata explicitly.
- CSV import/export still needs tax-field columns so user-provided tax metadata is not silently dropped.
- A Prisma migration or `db push` step needs to be run and committed/validated according to the repo's migration workflow.

## Testing

I added `src/utils/taxReport.test.ts`, but I did not run the full test/typecheck suite in this environment. Please run:

```bash
npm run check
```

and then address any integration/type issues before merging.