### PR TITLE
Harden grouped transfer lifecycle

### DIFF
--- a/electron/ipc/registerDbHandlers.js
+++ b/electron/ipc/registerDbHandlers.js
@@ -1,353 +1,14 @@
-const {randomUUID} = require('node:crypto')
 const {ipcMain} = require('electron')
 const {getPrisma} = require('../db')
-const {requireDate} = require('../utils/date')
-
-function normalizeText(value) {
-    if (typeof value !== 'string') return null
-    const trimmed = value.trim()
-    return trimmed.length ? trimmed : null
-}
-
-function requireText(value, fieldName) {
-    const normalized = normalizeText(value)
-    if (!normalized) {
-        throw new Error(`${fieldName} est obligatoire.`)
-    }
-    return normalized
-}
-
-function normalizeCurrency(value) {
-    return (normalizeText(value) || 'CAD').toUpperCase()
-}
-
-function requirePositiveNumber(value, fieldName) {
-    const parsed = Number(value)
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-        throw new Error(`${fieldName} doit être un nombre strictement positif.`)
-    }
-    return parsed
-}
-
-function requireId(value, fieldName) {
-    const parsed = Number(value)
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-        throw new Error(`${fieldName} est invalide.`)
-    }
-    return parsed
-}
-
-function includeTransactionRelations() {
-    return {
-        account: true,
-        category: true,
-        transferPeerAccount: true,
-    }
-}
-
-function normalizeConversionMode(value, sourceCurrency, accountCurrency) {
-    const normalized = normalizeText(value)?.toUpperCase()
-
-    if (sourceCurrency === accountCurrency) {
-        return 'NONE'
-    }
-
-    if (normalized === 'MANUAL' || normalized === 'AUTOMATIC') {
-        return normalized
-    }
-
-    throw new Error('Le mode de conversion est invalide.')
-}
-
-function buildAccountPayload(data) {
-    return {
-        name: requireText(data?.name, 'Le nom du compte'),
-        type: data?.type,
-        currency: normalizeCurrency(data?.currency),
-        description: normalizeText(data?.description),
-    }
-}
-
-function buildCategoryPayload(data) {
-    return {
-        name: requireText(data?.name, 'Le nom de la catégorie'),
-        kind: data?.kind,
-        color: normalizeText(data?.color),
-        description: normalizeText(data?.description),
-    }
-}
-
-async function buildTransactionPayload(prisma, data) {
-    const accountId = requireId(data?.accountId, 'Le compte')
-    const account = await prisma.account.findUnique({where: {id: accountId}})
-
-    if (!account) {
-        throw new Error('Le compte sélectionné est introuvable.')
-    }
-
-    const accountCurrency = normalizeCurrency(account.currency)
-    const sourceAmount = requirePositiveNumber(
-        data?.sourceAmount ?? data?.amount,
-        'Le montant',
-    )
-
-    const sourceCurrency = normalizeCurrency(
-        data?.sourceCurrency ?? accountCurrency,
-    )
-
-    const conversionMode = normalizeConversionMode(
-        data?.conversionMode,
-        sourceCurrency,
-        accountCurrency,
-    )
-
-    let bookedAmount = sourceAmount
-    let exchangeRate = 1
-    let exchangeProvider = 'ACCOUNT'
-    let exchangeDate = requireDate(data?.exchangeDate || data?.date)
-
-    if (sourceCurrency !== accountCurrency) {
-        bookedAmount = requirePositiveNumber(
-            data?.amount,
-            'Le montant converti dans la devise du compte',
-        )
-
-        if (conversionMode === 'AUTOMATIC') {
-            exchangeRate = requirePositiveNumber(data?.exchangeRate, 'Le taux de change')
-            exchangeProvider = requireText(data?.exchangeProvider, 'La source du taux')
-            exchangeDate = requireDate(data?.exchangeDate || data?.date)
-        } else if (conversionMode === 'MANUAL') {
-            exchangeRate = requirePositiveNumber(
-                data?.exchangeRate ?? bookedAmount / sourceAmount,
-                'Le taux de change',
-            )
-            exchangeProvider = normalizeText(data?.exchangeProvider) || 'MANUAL'
-            exchangeDate = requireDate(data?.exchangeDate || data?.date)
-        }
-    }
-
-    return {
-        label: requireText(data?.label, 'Le libellé'),
-        amount: bookedAmount,
-        sourceAmount,
-        sourceCurrency,
-        conversionMode,
-        exchangeRate,
-        exchangeProvider,
-        exchangeDate,
-        kind: data?.kind,
-        date: requireDate(data?.date),
-        note: normalizeText(data?.note),
-        accountId,
-        categoryId: data?.kind === 'TRANSFER'
-            ? null
-            : (data?.categoryId ? requireId(data.categoryId, 'La catégorie') : null),
-        transferGroup: null,
-        transferDirection: null,
-        transferPeerAccountId: null,
-    }
-}
-
-async function buildInternalTransferPayload(prisma, data, transferGroup = null) {
-    const sourceAccountId = requireId(data?.accountId, 'Le compte source')
-    const targetAccountId = requireId(data?.transferTargetAccountId, 'Le compte destination')
-
-    if (sourceAccountId === targetAccountId) {
-        throw new Error('Le compte source et le compte destination doivent être différents.')
-    }
-
-    const [sourceAccount, targetAccount] = await Promise.all([
-        prisma.account.findUnique({where: {id: sourceAccountId}}),
-        prisma.account.findUnique({where: {id: targetAccountId}}),
-    ])
-
-    if (!sourceAccount) {
-        throw new Error('Le compte source est introuvable.')
-    }
-
-    if (!targetAccount) {
-        throw new Error('Le compte destination est introuvable.')
-    }
-
-    const label = requireText(data?.label, 'Le libellé')
-    const date = requireDate(data?.date)
-    const note = normalizeText(data?.note)
-    const debitAmount = requirePositiveNumber(data?.sourceAmount ?? data?.amount, 'Le montant transféré')
-    const sourceCurrency = normalizeCurrency(sourceAccount.currency)
-    const targetCurrency = normalizeCurrency(targetAccount.currency)
-    const conversionMode = normalizeConversionMode(data?.conversionMode, sourceCurrency, targetCurrency)
-
-    let creditedAmount = debitAmount
-    let exchangeRate = 1
-    let exchangeProvider = 'ACCOUNT'
-    let exchangeDate = requireDate(data?.exchangeDate || data?.date)
-
-    if (sourceCurrency !== targetCurrency) {
-        creditedAmount = requirePositiveNumber(
-            data?.amount,
-            'Le montant crédité dans la devise du compte destination',
-        )
-
-        if (conversionMode === 'AUTOMATIC') {
-            exchangeRate = requirePositiveNumber(data?.exchangeRate, 'Le taux de change')
-            exchangeProvider = requireText(data?.exchangeProvider, 'La source du taux')
-            exchangeDate = requireDate(data?.exchangeDate || data?.date)
-        } else if (conversionMode === 'MANUAL') {
-            exchangeRate = requirePositiveNumber(
-                data?.exchangeRate ?? creditedAmount / debitAmount,
-                'Le taux de change',
-            )
-            exchangeProvider = normalizeText(data?.exchangeProvider) || 'MANUAL'
-            exchangeDate = requireDate(data?.exchangeDate || data?.date)
-        }
-    }
-
-    const group = transferGroup || randomUUID()
-
-    return {
-        transferGroup: group,
-        outgoingData: {
-            label,
-            amount: debitAmount,
-            sourceAmount: debitAmount,
-            sourceCurrency,
-            conversionMode: 'NONE',
-            exchangeRate: 1,
-            exchangeProvider: 'ACCOUNT',
-            exchangeDate,
-            kind: 'TRANSFER',
-            date,
-            note,
-            accountId: sourceAccount.id,
-            categoryId: null,
-            transferGroup: group,
-            transferDirection: 'OUT',
-            transferPeerAccountId: targetAccount.id,
-        },
-        incomingData: {
-            label,
-            amount: creditedAmount,
-            sourceAmount: debitAmount,
-            sourceCurrency,
-            conversionMode,
-            exchangeRate,
-            exchangeProvider,
-            exchangeDate,
-            kind: 'TRANSFER',
-            date,
-            note,
-            accountId: targetAccount.id,
-            categoryId: null,
-            transferGroup: group,
-            transferDirection: 'IN',
-            transferPeerAccountId: sourceAccount.id,
-        },
-    }
-}
-
-async function createInternalTransfer(prisma, data, transferGroup = null) {
-    const payload = await buildInternalTransferPayload(prisma, data, transferGroup)
-
-    const created = await prisma.$transaction(async (tx) => {
-        const outgoing = await tx.transaction.create({data: payload.outgoingData})
-        await tx.transaction.create({data: payload.incomingData})
-
-        return tx.transaction.findUnique({
-            where: {id: outgoing.id},
-            include: includeTransactionRelations(),
-        })
-    })
-
-    return created
-}
-
-async function updateInternalTransfer(prisma, currentTransactionId, data, existingTransferGroup) {
-    const payload = await buildInternalTransferPayload(prisma, data, existingTransferGroup)
-    const siblings = await prisma.transaction.findMany({
-        where: {transferGroup: payload.transferGroup},
-        orderBy: {id: 'asc'},
-    })
-
-    const outgoingSibling = siblings.find((transaction) => transaction.transferDirection === 'OUT')
-    const incomingSibling = siblings.find((transaction) => transaction.transferDirection === 'IN')
-
-    return prisma.$transaction(async (tx) => {
-        let outgoingId = outgoingSibling?.id || null
-        let incomingId = incomingSibling?.id || null
-
-        if (outgoingId) {
-            await tx.transaction.update({
-                where: {id: outgoingId},
-                data: payload.outgoingData,
-            })
-        } else {
-            const createdOutgoing = await tx.transaction.create({data: payload.outgoingData})
-            outgoingId = createdOutgoing.id
-        }
-
-        if (incomingId) {
-            await tx.transaction.update({
-                where: {id: incomingId},
-                data: payload.incomingData,
-            })
-        } else {
-            const createdIncoming = await tx.transaction.create({data: payload.incomingData})
-            incomingId = createdIncoming.id
-        }
-
-        await tx.transaction.deleteMany({
-            where: {
-                transferGroup: payload.transferGroup,
-                id: {
-                    notIn: [outgoingId, incomingId].filter(Boolean),
-                },
-            },
-        })
-
-        const preferredId = currentTransactionId === incomingSibling?.id ? incomingId : outgoingId
-        return tx.transaction.findUnique({
-            where: {id: preferredId},
-            include: includeTransactionRelations(),
-        })
-    })
-}
-
-async function convertTransferToStandard(prisma, currentTransactionId, data, existingTransferGroup) {
-    const standardPayload = await buildTransactionPayload(prisma, data)
-
-    return prisma.$transaction(async (tx) => {
-        await tx.transaction.deleteMany({
-            where: {
-                transferGroup: existingTransferGroup,
-                id: {not: currentTransactionId},
-            },
-        })
-
-        return tx.transaction.update({
-            where: {id: currentTransactionId},
-            data: standardPayload,
-            include: includeTransactionRelations(),
-        })
-    })
-}
-
-async function convertStandardToTransfer(prisma, currentTransactionId, data) {
-    const payload = await buildInternalTransferPayload(prisma, data)
-
-    return prisma.$transaction(async (tx) => {
-        await tx.transaction.update({
-            where: {id: currentTransactionId},
-            data: payload.outgoingData,
-        })
-
-        await tx.transaction.create({data: payload.incomingData})
-
-        return tx.transaction.findUnique({
-            where: {id: currentTransactionId},
-            include: includeTransactionRelations(),
-        })
-    })
-}
+const {
+    buildAccountPayload,
+    buildCategoryPayload,
+    createTransaction,
+    deleteTransaction,
+    includeTransactionRelations,
+    requireId,
+    updateTransaction,
+} = require('./transactionHandlers')
 
 function registerDbHandlers() {
     const prisma = getPrisma()
@@ -366,18 +27,14 @@ function registerDbHandlers() {
 
     ipcMain.handle('db:account:update', async (_event, id, data) => {
         return prisma.account.update({
-            where: {
-                id: requireId(id, 'Le compte'),
-            },
+            where: {id: requireId(id, 'Le compte')},
             data: buildAccountPayload(data),
         })
     })
 
     ipcMain.handle('db:account:delete', async (_event, id) => {
         return prisma.account.delete({
-            where: {
-                id: requireId(id, 'Le compte'),
-            },
+            where: {id: requireId(id, 'Le compte')},
         })
     })
 
@@ -395,18 +52,14 @@ function registerDbHandlers() {
 
     ipcMain.handle('db:category:update', async (_event, id, data) => {
         return prisma.category.update({
-            where: {
-                id: requireId(id, 'La catégorie'),
-            },
+            where: {id: requireId(id, 'La catégorie')},
             data: buildCategoryPayload(data),
         })
     })
 
     ipcMain.handle('db:category:delete', async (_event, id) => {
         return prisma.category.delete({
-            where: {
-                id: requireId(id, 'La catégorie'),
-            },
+            where: {id: requireId(id, 'La catégorie')},
         })
     })
 
@@ -421,74 +74,15 @@ function registerDbHandlers() {
     })
 
     ipcMain.handle('db:transaction:create', async (_event, data) => {
-        if (data?.kind === 'TRANSFER' && data?.transferTargetAccountId) {
-            return createInternalTransfer(prisma, data)
-        }
-
-        return prisma.transaction.create({
-            data: await buildTransactionPayload(prisma, data),
-            include: includeTransactionRelations(),
-        })
+        return createTransaction(prisma, data)
     })
 
     ipcMain.handle('db:transaction:update', async (_event, id, data) => {
-        const transactionId = requireId(id, 'La transaction')
-        const existing = await prisma.transaction.findUnique({
-            where: {id: transactionId},
-            include: includeTransactionRelations(),
-        })
-
-        if (!existing) {
-            throw new Error('La transaction est introuvable.')
-        }
-
-        const wantsInternalTransfer = data?.kind === 'TRANSFER' && data?.transferTargetAccountId
-
-        if (existing.transferGroup) {
-            if (wantsInternalTransfer) {
-                return updateInternalTransfer(prisma, transactionId, data, existing.transferGroup)
-            }
-
-            return convertTransferToStandard(prisma, transactionId, data, existing.transferGroup)
-        }
-
-        if (wantsInternalTransfer) {
-            return convertStandardToTransfer(prisma, transactionId, data)
-        }
-
-        return prisma.transaction.update({
-            where: {
-                id: transactionId,
-            },
-            data: await buildTransactionPayload(prisma, data),
-            include: includeTransactionRelations(),
-        })
+        return updateTransaction(prisma, id, data)
     })
 
     ipcMain.handle('db:transaction:delete', async (_event, id) => {
-        const transactionId = requireId(id, 'La transaction')
-        const existing = await prisma.transaction.findUnique({
-            where: {id: transactionId},
-            include: includeTransactionRelations(),
-        })
-
-        if (!existing) {
-            throw new Error('La transaction est introuvable.')
-        }
-
-        if (existing.transferGroup) {
-            await prisma.transaction.deleteMany({
-                where: {transferGroup: existing.transferGroup},
-            })
-            return existing
-        }
-
-        return prisma.transaction.delete({
-            where: {
-                id: transactionId,
-            },
-            include: includeTransactionRelations(),
-        })
+        return deleteTransaction(prisma, id)
     })
 }
 

--- a/electron/ipc/transactionHandlers.js
+++ b/electron/ipc/transactionHandlers.js
@@ -1,0 +1,515 @@
+const {randomUUID} = require('node:crypto')
+const {requireDate} = require('../utils/date')
+
+function normalizeText(value) {
+    if (typeof value !== 'string') return null
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+}
+
+function requireText(value, fieldName) {
+    const normalized = normalizeText(value)
+    if (!normalized) {
+        throw new Error(`${fieldName} est obligatoire.`)
+    }
+    return normalized
+}
+
+function normalizeCurrency(value) {
+    return (normalizeText(value) || 'CAD').toUpperCase()
+}
+
+function requirePositiveNumber(value, fieldName) {
+    const parsed = Number(value)
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`${fieldName} doit être un nombre strictement positif.`)
+    }
+    return parsed
+}
+
+function requireId(value, fieldName) {
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`${fieldName} est invalide.`)
+    }
+    return parsed
+}
+
+function includeTransactionRelations() {
+    return {
+        account: true,
+        category: true,
+        transferPeerAccount: true,
+    }
+}
+
+function normalizeConversionMode(value, sourceCurrency, accountCurrency) {
+    const normalized = normalizeText(value)?.toUpperCase()
+
+    if (sourceCurrency === accountCurrency) {
+        return 'NONE'
+    }
+
+    if (normalized === 'MANUAL' || normalized === 'AUTOMATIC') {
+        return normalized
+    }
+
+    throw new Error('Le mode de conversion est invalide.')
+}
+
+function buildAccountPayload(data) {
+    return {
+        name: requireText(data?.name, 'Le nom du compte'),
+        type: data?.type,
+        currency: normalizeCurrency(data?.currency),
+        description: normalizeText(data?.description),
+    }
+}
+
+function buildCategoryPayload(data) {
+    return {
+        name: requireText(data?.name, 'Le nom de la catégorie'),
+        kind: data?.kind,
+        color: normalizeText(data?.color),
+        description: normalizeText(data?.description),
+    }
+}
+
+async function buildTransactionPayload(prisma, data) {
+    const accountId = requireId(data?.accountId, 'Le compte')
+    const account = await prisma.account.findUnique({where: {id: accountId}})
+
+    if (!account) {
+        throw new Error('Le compte sélectionné est introuvable.')
+    }
+
+    const accountCurrency = normalizeCurrency(account.currency)
+    const sourceAmount = requirePositiveNumber(
+        data?.sourceAmount ?? data?.amount,
+        'Le montant',
+    )
+
+    const sourceCurrency = normalizeCurrency(
+        data?.sourceCurrency ?? accountCurrency,
+    )
+
+    const conversionMode = normalizeConversionMode(
+        data?.conversionMode,
+        sourceCurrency,
+        accountCurrency,
+    )
+
+    let bookedAmount = sourceAmount
+    let exchangeRate = 1
+    let exchangeProvider = 'ACCOUNT'
+    let exchangeDate = requireDate(data?.exchangeDate || data?.date)
+
+    if (sourceCurrency !== accountCurrency) {
+        bookedAmount = requirePositiveNumber(
+            data?.amount,
+            'Le montant converti dans la devise du compte',
+        )
+
+        if (conversionMode === 'AUTOMATIC') {
+            exchangeRate = requirePositiveNumber(data?.exchangeRate, 'Le taux de change')
+            exchangeProvider = requireText(data?.exchangeProvider, 'La source du taux')
+            exchangeDate = requireDate(data?.exchangeDate || data?.date)
+        } else if (conversionMode === 'MANUAL') {
+            exchangeRate = requirePositiveNumber(
+                data?.exchangeRate ?? bookedAmount / sourceAmount,
+                'Le taux de change',
+            )
+            exchangeProvider = normalizeText(data?.exchangeProvider) || 'MANUAL'
+            exchangeDate = requireDate(data?.exchangeDate || data?.date)
+        }
+    }
+
+    return {
+        label: requireText(data?.label, 'Le libellé'),
+        amount: bookedAmount,
+        sourceAmount,
+        sourceCurrency,
+        conversionMode,
+        exchangeRate,
+        exchangeProvider,
+        exchangeDate,
+        kind: data?.kind,
+        date: requireDate(data?.date),
+        note: normalizeText(data?.note),
+        accountId,
+        categoryId: data?.kind === 'TRANSFER'
+            ? null
+            : (data?.categoryId ? requireId(data.categoryId, 'La catégorie') : null),
+        transferGroup: null,
+        transferDirection: null,
+        transferPeerAccountId: null,
+    }
+}
+
+async function buildInternalTransferPayload(prisma, data, transferGroup = null) {
+    const sourceAccountId = requireId(data?.accountId, 'Le compte source')
+    const targetAccountId = requireId(data?.transferTargetAccountId, 'Le compte destination')
+
+    if (sourceAccountId === targetAccountId) {
+        throw new Error('Le compte source et le compte destination doivent être différents.')
+    }
+
+    const [sourceAccount, targetAccount] = await Promise.all([
+        prisma.account.findUnique({where: {id: sourceAccountId}}),
+        prisma.account.findUnique({where: {id: targetAccountId}}),
+    ])
+
+    if (!sourceAccount) {
+        throw new Error('Le compte source est introuvable.')
+    }
+
+    if (!targetAccount) {
+        throw new Error('Le compte destination est introuvable.')
+    }
+
+    const label = requireText(data?.label, 'Le libellé')
+    const date = requireDate(data?.date)
+    const note = normalizeText(data?.note)
+    const debitAmount = requirePositiveNumber(data?.sourceAmount ?? data?.amount, 'Le montant transféré')
+    const sourceCurrency = normalizeCurrency(sourceAccount.currency)
+    const targetCurrency = normalizeCurrency(targetAccount.currency)
+    const conversionMode = normalizeConversionMode(data?.conversionMode, sourceCurrency, targetCurrency)
+
+    let creditedAmount = debitAmount
+    let exchangeRate = 1
+    let exchangeProvider = 'ACCOUNT'
+    let exchangeDate = requireDate(data?.exchangeDate || data?.date)
+
+    if (sourceCurrency !== targetCurrency) {
+        creditedAmount = requirePositiveNumber(
+            data?.amount,
+            'Le montant crédité dans la devise du compte destination',
+        )
+
+        if (conversionMode === 'AUTOMATIC') {
+            exchangeRate = requirePositiveNumber(data?.exchangeRate, 'Le taux de change')
+            exchangeProvider = requireText(data?.exchangeProvider, 'La source du taux')
+            exchangeDate = requireDate(data?.exchangeDate || data?.date)
+        } else if (conversionMode === 'MANUAL') {
+            exchangeRate = requirePositiveNumber(
+                data?.exchangeRate ?? creditedAmount / debitAmount,
+                'Le taux de change',
+            )
+            exchangeProvider = normalizeText(data?.exchangeProvider) || 'MANUAL'
+            exchangeDate = requireDate(data?.exchangeDate || data?.date)
+        }
+    }
+
+    const group = transferGroup || randomUUID()
+
+    return {
+        transferGroup: group,
+        outgoingData: {
+            label,
+            amount: debitAmount,
+            sourceAmount: debitAmount,
+            sourceCurrency,
+            conversionMode: 'NONE',
+            exchangeRate: 1,
+            exchangeProvider: 'ACCOUNT',
+            exchangeDate,
+            kind: 'TRANSFER',
+            date,
+            note,
+            accountId: sourceAccount.id,
+            categoryId: null,
+            transferGroup: group,
+            transferDirection: 'OUT',
+            transferPeerAccountId: targetAccount.id,
+        },
+        incomingData: {
+            label,
+            amount: creditedAmount,
+            sourceAmount: debitAmount,
+            sourceCurrency,
+            conversionMode,
+            exchangeRate,
+            exchangeProvider,
+            exchangeDate,
+            kind: 'TRANSFER',
+            date,
+            note,
+            accountId: targetAccount.id,
+            categoryId: null,
+            transferGroup: group,
+            transferDirection: 'IN',
+            transferPeerAccountId: sourceAccount.id,
+        },
+    }
+}
+
+function invalidTransferGroupError(transferGroup) {
+    return new Error(`Le transfert interne ${transferGroup} est incohérent.`)
+}
+
+function assertCoherentTransferPair(rows, transferGroup) {
+    if (rows.length !== 2) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    const outgoing = rows.find((transaction) => transaction.transferDirection === 'OUT')
+    const incoming = rows.find((transaction) => transaction.transferDirection === 'IN')
+
+    if (!outgoing || !incoming) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    if (outgoing.kind !== 'TRANSFER' || incoming.kind !== 'TRANSFER') {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    if (outgoing.transferGroup !== transferGroup || incoming.transferGroup !== transferGroup) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    if (outgoing.accountId === incoming.accountId) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    if (
+        outgoing.transferPeerAccountId !== incoming.accountId ||
+        incoming.transferPeerAccountId !== outgoing.accountId
+    ) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    return {outgoing, incoming}
+}
+
+function resolveEditableTransferGroup(rows, currentTransactionId, transferGroup) {
+    if (!rows.some((transaction) => transaction.id === currentTransactionId)) {
+        throw new Error('La transaction ne fait plus partie de ce transfert interne.')
+    }
+
+    if (rows.length > 2) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    const outgoingRows = rows.filter((transaction) => transaction.transferDirection === 'OUT')
+    const incomingRows = rows.filter((transaction) => transaction.transferDirection === 'IN')
+    const unknownDirectionRows = rows.filter((transaction) => (
+        transaction.transferDirection !== 'OUT' && transaction.transferDirection !== 'IN'
+    ))
+
+    if (
+        outgoingRows.length > 1 ||
+        incomingRows.length > 1 ||
+        unknownDirectionRows.length > 0
+    ) {
+        throw invalidTransferGroupError(transferGroup)
+    }
+
+    if (rows.length === 2) {
+        return assertCoherentTransferPair(rows, transferGroup)
+    }
+
+    return {
+        outgoing: outgoingRows[0] || null,
+        incoming: incomingRows[0] || null,
+    }
+}
+
+async function findTransferGroupRows(prisma, transferGroup) {
+    return prisma.transaction.findMany({
+        where: {transferGroup},
+        orderBy: {id: 'asc'},
+    })
+}
+
+async function createInternalTransfer(prisma, data, transferGroup = null) {
+    return prisma.$transaction(async (tx) => {
+        const payload = await buildInternalTransferPayload(tx, data, transferGroup)
+        const outgoing = await tx.transaction.create({data: payload.outgoingData})
+        await tx.transaction.create({data: payload.incomingData})
+
+        const createdRows = await findTransferGroupRows(tx, payload.transferGroup)
+        assertCoherentTransferPair(createdRows, payload.transferGroup)
+
+        return tx.transaction.findUnique({
+            where: {id: outgoing.id},
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+async function updateInternalTransfer(prisma, currentTransactionId, data, existingTransferGroup) {
+    return prisma.$transaction(async (tx) => {
+        const payload = await buildInternalTransferPayload(tx, data, existingTransferGroup)
+        const siblings = await findTransferGroupRows(tx, payload.transferGroup)
+        const {outgoing: outgoingSibling, incoming: incomingSibling} = resolveEditableTransferGroup(
+            siblings,
+            currentTransactionId,
+            payload.transferGroup,
+        )
+
+        let outgoingId = outgoingSibling?.id || null
+        let incomingId = incomingSibling?.id || null
+
+        if (outgoingId) {
+            await tx.transaction.update({
+                where: {id: outgoingId},
+                data: payload.outgoingData,
+            })
+        } else {
+            const createdOutgoing = await tx.transaction.create({data: payload.outgoingData})
+            outgoingId = createdOutgoing.id
+        }
+
+        if (incomingId) {
+            await tx.transaction.update({
+                where: {id: incomingId},
+                data: payload.incomingData,
+            })
+        } else {
+            const createdIncoming = await tx.transaction.create({data: payload.incomingData})
+            incomingId = createdIncoming.id
+        }
+
+        const updatedRows = await findTransferGroupRows(tx, payload.transferGroup)
+        assertCoherentTransferPair(updatedRows, payload.transferGroup)
+
+        const preferredId = currentTransactionId === incomingSibling?.id ? incomingId : outgoingId
+        return tx.transaction.findUnique({
+            where: {id: preferredId},
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+async function convertTransferToStandard(prisma, currentTransactionId, data, existingTransferGroup) {
+    return prisma.$transaction(async (tx) => {
+        const standardPayload = await buildTransactionPayload(tx, data)
+
+        await tx.transaction.deleteMany({
+            where: {
+                transferGroup: existingTransferGroup,
+                id: {not: currentTransactionId},
+            },
+        })
+
+        return tx.transaction.update({
+            where: {id: currentTransactionId},
+            data: standardPayload,
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+async function convertStandardToTransfer(prisma, currentTransactionId, data) {
+    return prisma.$transaction(async (tx) => {
+        const payload = await buildInternalTransferPayload(tx, data)
+
+        await tx.transaction.update({
+            where: {id: currentTransactionId},
+            data: payload.outgoingData,
+        })
+
+        await tx.transaction.create({data: payload.incomingData})
+
+        const updatedRows = await findTransferGroupRows(tx, payload.transferGroup)
+        assertCoherentTransferPair(updatedRows, payload.transferGroup)
+
+        return tx.transaction.findUnique({
+            where: {id: currentTransactionId},
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+async function createTransaction(prisma, data) {
+    if (data?.kind === 'TRANSFER' && data?.transferTargetAccountId) {
+        return createInternalTransfer(prisma, data)
+    }
+
+    return prisma.transaction.create({
+        data: await buildTransactionPayload(prisma, data),
+        include: includeTransactionRelations(),
+    })
+}
+
+async function updateTransaction(prisma, id, data) {
+    const transactionId = requireId(id, 'La transaction')
+    const existing = await prisma.transaction.findUnique({
+        where: {id: transactionId},
+        include: includeTransactionRelations(),
+    })
+
+    if (!existing) {
+        throw new Error('La transaction est introuvable.')
+    }
+
+    const wantsInternalTransfer = data?.kind === 'TRANSFER' && data?.transferTargetAccountId
+
+    if (existing.transferGroup) {
+        if (wantsInternalTransfer) {
+            return updateInternalTransfer(prisma, transactionId, data, existing.transferGroup)
+        }
+
+        return convertTransferToStandard(prisma, transactionId, data, existing.transferGroup)
+    }
+
+    if (wantsInternalTransfer) {
+        return convertStandardToTransfer(prisma, transactionId, data)
+    }
+
+    return prisma.transaction.update({
+        where: {id: transactionId},
+        data: await buildTransactionPayload(prisma, data),
+        include: includeTransactionRelations(),
+    })
+}
+
+async function deleteTransaction(prisma, id) {
+    const transactionId = requireId(id, 'La transaction')
+
+    return prisma.$transaction(async (tx) => {
+        const existing = await tx.transaction.findUnique({
+            where: {id: transactionId},
+            include: includeTransactionRelations(),
+        })
+
+        if (!existing) {
+            throw new Error('La transaction est introuvable.')
+        }
+
+        if (existing.transferGroup) {
+            await tx.transaction.deleteMany({
+                where: {transferGroup: existing.transferGroup},
+            })
+            return existing
+        }
+
+        return tx.transaction.delete({
+            where: {id: transactionId},
+            include: includeTransactionRelations(),
+        })
+    })
+}
+
+module.exports = {
+    assertCoherentTransferPair,
+    buildAccountPayload,
+    buildCategoryPayload,
+    buildInternalTransferPayload,
+    buildTransactionPayload,
+    convertStandardToTransfer,
+    convertTransferToStandard,
+    createInternalTransfer,
+    createTransaction,
+    deleteTransaction,
+    includeTransactionRelations,
+    normalizeConversionMode,
+    normalizeCurrency,
+    normalizeText,
+    requireId,
+    requirePositiveNumber,
+    requireText,
+    resolveEditableTransferGroup,
+    updateInternalTransfer,
+    updateTransaction,
+}

--- a/src/test/electron/transferLifecycle.test.ts
+++ b/src/test/electron/transferLifecycle.test.ts
@@ -1,0 +1,381 @@
+import {createRequire} from 'node:module'
+import {describe, expect, it} from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+    createInternalTransfer,
+    deleteTransaction,
+    updateInternalTransfer,
+} = require('../../../electron/ipc/transactionHandlers.js')
+
+type AccountRow = {
+    id: number
+    name: string
+    currency: string
+}
+
+type TransactionRow = {
+    id: number
+    label: string
+    amount: number
+    sourceAmount: number | null
+    sourceCurrency: string | null
+    conversionMode: string
+    exchangeRate: number | null
+    exchangeProvider: string | null
+    exchangeDate: Date | null
+    kind: string
+    date: Date
+    note: string | null
+    accountId: number
+    categoryId: number | null
+    transferGroup: string | null
+    transferDirection: string | null
+    transferPeerAccountId: number | null
+    createdAt: Date
+    updatedAt: Date
+}
+
+type FakeDb = {
+    accounts: AccountRow[]
+    transactions: TransactionRow[]
+}
+
+function makeAccount(id: number, name: string, currency = 'CAD'): AccountRow {
+    return {id, name, currency}
+}
+
+function cloneDate(value: Date | null) {
+    return value ? new Date(value.getTime()) : null
+}
+
+function cloneTransaction(transaction: TransactionRow): TransactionRow {
+    return {
+        ...transaction,
+        date: new Date(transaction.date.getTime()),
+        exchangeDate: cloneDate(transaction.exchangeDate),
+        createdAt: new Date(transaction.createdAt.getTime()),
+        updatedAt: new Date(transaction.updatedAt.getTime()),
+    }
+}
+
+function cloneDb(db: FakeDb): FakeDb {
+    return {
+        accounts: db.accounts.map((account) => ({...account})),
+        transactions: db.transactions.map(cloneTransaction),
+    }
+}
+
+function matchesIdFilter(id: number, filter: unknown) {
+    if (!filter || typeof filter !== 'object') return true
+    if ('not' in filter && id === Number((filter as {not: number}).not)) return false
+    if ('notIn' in filter && (filter as {notIn: number[]}).notIn.includes(id)) return false
+    return true
+}
+
+function matchesWhere(transaction: TransactionRow, where: {transferGroup?: string | null; id?: unknown}) {
+    if (where.transferGroup !== undefined && transaction.transferGroup !== where.transferGroup) {
+        return false
+    }
+
+    if (typeof where.id === 'number') {
+        return transaction.id === where.id
+    }
+
+    return matchesIdFilter(transaction.id, where.id)
+}
+
+function createFakePrisma(db: FakeDb) {
+    let nextTransactionId = Math.max(0, ...db.transactions.map((transaction) => transaction.id)) + 1
+
+    const withRelations = (transaction: TransactionRow) => ({
+        ...cloneTransaction(transaction),
+        account: db.accounts.find((account) => account.id === transaction.accountId) || null,
+        category: null,
+        transferPeerAccount: db.accounts.find((account) => account.id === transaction.transferPeerAccountId) || null,
+    })
+
+    const prisma: any = {
+        account: {
+            findUnique: async ({where}: {where: {id: number}}) => (
+                db.accounts.find((account) => account.id === where.id) || null
+            ),
+        },
+        transaction: {
+            create: async ({data}: {data: Omit<TransactionRow, 'id' | 'createdAt' | 'updatedAt'>}) => {
+                const now = new Date('2026-04-25T12:00:00.000Z')
+                const transaction = {
+                    id: nextTransactionId,
+                    ...data,
+                    createdAt: now,
+                    updatedAt: now,
+                } as TransactionRow
+                nextTransactionId += 1
+                db.transactions.push(transaction)
+                return withRelations(transaction)
+            },
+            findUnique: async ({where}: {where: {id: number}}) => {
+                const transaction = db.transactions.find((entry) => entry.id === where.id)
+                return transaction ? withRelations(transaction) : null
+            },
+            findMany: async ({where}: {where: {transferGroup?: string | null}}) => {
+                return db.transactions
+                    .filter((transaction) => matchesWhere(transaction, where))
+                    .sort((a, b) => a.id - b.id)
+                    .map(withRelations)
+            },
+            update: async ({where, data}: {where: {id: number}; data: Partial<TransactionRow>}) => {
+                const index = db.transactions.findIndex((transaction) => transaction.id === where.id)
+                if (index < 0) throw new Error('Not found')
+
+                db.transactions[index] = {
+                    ...db.transactions[index],
+                    ...data,
+                    updatedAt: new Date('2026-04-25T12:01:00.000Z'),
+                }
+                return withRelations(db.transactions[index])
+            },
+            delete: async ({where}: {where: {id: number}}) => {
+                const index = db.transactions.findIndex((transaction) => transaction.id === where.id)
+                if (index < 0) throw new Error('Not found')
+
+                const [deleted] = db.transactions.splice(index, 1)
+                return withRelations(deleted)
+            },
+            deleteMany: async ({where}: {where: {transferGroup?: string | null; id?: unknown}}) => {
+                const before = db.transactions.length
+                db.transactions = db.transactions.filter((transaction) => !matchesWhere(transaction, where))
+                return {count: before - db.transactions.length}
+            },
+        },
+        $transaction: async (callback: (tx: unknown) => Promise<unknown>) => {
+            const snapshot = cloneDb(db)
+            const nextIdSnapshot = nextTransactionId
+
+            try {
+                return await callback(prisma)
+            } catch (error) {
+                db.accounts = snapshot.accounts
+                db.transactions = snapshot.transactions
+                nextTransactionId = nextIdSnapshot
+                throw error
+            }
+        },
+    }
+
+    return prisma
+}
+
+function transferPayload(overrides: Record<string, unknown> = {}) {
+    return {
+        label: 'Virement épargne',
+        amount: 125,
+        sourceAmount: 125,
+        conversionMode: 'NONE',
+        date: '2026-04-20',
+        accountId: 1,
+        transferTargetAccountId: 2,
+        kind: 'TRANSFER',
+        ...overrides,
+    }
+}
+
+describe('internal transfer lifecycle', () => {
+    it('creates a debit and credit pair with one coherent transferGroup', async () => {
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: [],
+        }
+        const prisma = createFakePrisma(db)
+
+        const result = await createInternalTransfer(prisma, transferPayload())
+
+        expect(result.transferDirection).toBe('OUT')
+        expect(db.transactions).toHaveLength(2)
+
+        const [outgoing, incoming] = db.transactions
+        expect(outgoing.transferGroup).toBeTruthy()
+        expect(incoming.transferGroup).toBe(outgoing.transferGroup)
+        expect(outgoing.transferDirection).toBe('OUT')
+        expect(incoming.transferDirection).toBe('IN')
+        expect(outgoing.accountId).toBe(1)
+        expect(incoming.accountId).toBe(2)
+        expect(outgoing.transferPeerAccountId).toBe(2)
+        expect(incoming.transferPeerAccountId).toBe(1)
+    })
+
+    it('updates both sides while preserving the existing transferGroup', async () => {
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: [],
+        }
+        const prisma = createFakePrisma(db)
+        await createInternalTransfer(prisma, transferPayload())
+        const group = db.transactions[0].transferGroup
+        const incomingId = db.transactions.find((transaction) => transaction.transferDirection === 'IN')?.id
+
+        const result = await updateInternalTransfer(
+            prisma,
+            incomingId,
+            transferPayload({label: 'Virement corrigé', amount: 200, sourceAmount: 200}),
+            group,
+        )
+
+        expect(result.id).toBe(incomingId)
+        expect(db.transactions).toHaveLength(2)
+        expect(new Set(db.transactions.map((transaction) => transaction.transferGroup))).toEqual(new Set([group]))
+        expect(db.transactions.every((transaction) => transaction.label === 'Virement corrigé')).toBe(true)
+
+        const outgoing = db.transactions.find((transaction) => transaction.transferDirection === 'OUT')
+        const incoming = db.transactions.find((transaction) => transaction.transferDirection === 'IN')
+        expect(outgoing?.amount).toBe(200)
+        expect(incoming?.amount).toBe(200)
+        expect(outgoing?.transferPeerAccountId).toBe(incoming?.accountId)
+        expect(incoming?.transferPeerAccountId).toBe(outgoing?.accountId)
+    })
+
+    it('repairs a one-sided transfer during edit instead of keeping an orphan', async () => {
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: [
+                {
+                    id: 7,
+                    label: 'Orphelin',
+                    amount: 50,
+                    sourceAmount: 50,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: new Date('2026-04-20T00:00:00.000Z'),
+                    kind: 'TRANSFER',
+                    date: new Date('2026-04-20T00:00:00.000Z'),
+                    note: null,
+                    accountId: 1,
+                    categoryId: null,
+                    transferGroup: 'group-orphan',
+                    transferDirection: 'OUT',
+                    transferPeerAccountId: 2,
+                    createdAt: new Date('2026-04-20T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-20T00:00:00.000Z'),
+                },
+            ],
+        }
+        const prisma = createFakePrisma(db)
+
+        await updateInternalTransfer(prisma, 7, transferPayload({amount: 75, sourceAmount: 75}), 'group-orphan')
+
+        expect(db.transactions).toHaveLength(2)
+        expect(db.transactions.map((transaction) => transaction.transferDirection).sort()).toEqual(['IN', 'OUT'])
+        expect(db.transactions.every((transaction) => transaction.transferGroup === 'group-orphan')).toBe(true)
+    })
+
+    it('rejects malformed transfer groups atomically', async () => {
+        const malformedRows = [
+            {
+                id: 10,
+                label: 'Bad A',
+                amount: 10,
+                sourceAmount: 10,
+                sourceCurrency: 'CAD',
+                conversionMode: 'NONE',
+                exchangeRate: 1,
+                exchangeProvider: 'ACCOUNT',
+                exchangeDate: new Date('2026-04-20T00:00:00.000Z'),
+                kind: 'TRANSFER',
+                date: new Date('2026-04-20T00:00:00.000Z'),
+                note: null,
+                accountId: 1,
+                categoryId: null,
+                transferGroup: 'group-bad',
+                transferDirection: 'OUT',
+                transferPeerAccountId: 2,
+                createdAt: new Date('2026-04-20T00:00:00.000Z'),
+                updatedAt: new Date('2026-04-20T00:00:00.000Z'),
+            },
+            {
+                id: 11,
+                label: 'Bad B',
+                amount: 10,
+                sourceAmount: 10,
+                sourceCurrency: 'CAD',
+                conversionMode: 'NONE',
+                exchangeRate: 1,
+                exchangeProvider: 'ACCOUNT',
+                exchangeDate: new Date('2026-04-20T00:00:00.000Z'),
+                kind: 'TRANSFER',
+                date: new Date('2026-04-20T00:00:00.000Z'),
+                note: null,
+                accountId: 2,
+                categoryId: null,
+                transferGroup: 'group-bad',
+                transferDirection: 'OUT',
+                transferPeerAccountId: 1,
+                createdAt: new Date('2026-04-20T00:00:00.000Z'),
+                updatedAt: new Date('2026-04-20T00:00:00.000Z'),
+            },
+        ]
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: malformedRows.map(cloneTransaction),
+        }
+        const prisma = createFakePrisma(db)
+
+        await expect(updateInternalTransfer(
+            prisma,
+            10,
+            transferPayload({label: 'Should not write'}),
+            'group-bad',
+        )).rejects.toThrow('Le transfert interne group-bad est incohérent.')
+
+        expect(db.transactions).toEqual(malformedRows)
+    })
+
+    it('deletes both sides when either side of a transfer is deleted', async () => {
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: [],
+        }
+        const prisma = createFakePrisma(db)
+        await createInternalTransfer(prisma, transferPayload())
+        const incomingId = db.transactions.find((transaction) => transaction.transferDirection === 'IN')?.id
+
+        await deleteTransaction(prisma, incomingId)
+
+        expect(db.transactions).toHaveLength(0)
+    })
+
+    it('deletes an orphaned transfer row by group without leaving residue', async () => {
+        const db = {
+            accounts: [makeAccount(1, 'Chèques'), makeAccount(2, 'Épargne')],
+            transactions: [
+                {
+                    id: 21,
+                    label: 'Orphelin',
+                    amount: 50,
+                    sourceAmount: 50,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: new Date('2026-04-20T00:00:00.000Z'),
+                    kind: 'TRANSFER',
+                    date: new Date('2026-04-20T00:00:00.000Z'),
+                    note: null,
+                    accountId: 1,
+                    categoryId: null,
+                    transferGroup: 'group-delete-orphan',
+                    transferDirection: 'OUT',
+                    transferPeerAccountId: 2,
+                    createdAt: new Date('2026-04-20T00:00:00.000Z'),
+                    updatedAt: new Date('2026-04-20T00:00:00.000Z'),
+                },
+            ],
+        }
+        const prisma = createFakePrisma(db)
+
+        await deleteTransaction(prisma, 21)
+
+        expect(db.transactions).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
## Résumé

- Extrait la logique de création / édition / suppression des transactions dans `electron/ipc/transactionHandlers.js` pour la rendre testable hors Electron.
- Rend les transferts internes atomiques via `prisma.$transaction` pour création, édition, conversion et suppression.
- Valide explicitement la cohérence d’un `transferGroup` : exactement une ligne `OUT`, une ligne `IN`, comptes croisés et peer accounts alignés.
- Répare un transfert orphelin à l’édition quand une seule moitié existe encore, mais refuse les groupes ambigus ou corrompus.
- Ajoute des tests unitaires couvrant création, édition des deux côtés, réparation d’orphelin, rejet atomique d’un groupe invalide et suppression.

## Tests

- Non exécutés localement : l’environnement de travail ne peut pas cloner le repo ni installer les dépendances depuis GitHub/npm.
- Les fichiers JavaScript ajoutés/modifiés ont été vérifiés syntaxiquement avec `node --check` sur une copie locale.

Closes #10