### PR TITLE
Fix JSON backup validation and versioning

### DIFF
--- a/docs/json-backup-format.md
+++ b/docs/json-backup-format.md
@@ -1,0 +1,54 @@
+# Format de backup JSON
+
+Le JSON est le format canonique de sauvegarde complète de Budget. Le CSV reste un format d’échange partiel.
+
+## Version
+
+- `kind`: `budget-backup`
+- version courante: `4`
+- versions lues: `2`, `3`, `4`
+
+Un fichier doit déclarer explicitement `kind`, `version`, `exportedAt` et `data`. Une version inconnue est refusée avec un message clair.
+
+## Collections
+
+`data` contient:
+
+- `accounts`
+- `categories`
+- `budgetTargets`
+- `recurringTemplates`
+- `transactions`
+- `taxProfiles`
+
+Pour les versions `2` et `3`, les champs fiscaux ajoutés ensuite sont optionnels. Le parseur les complète avec des valeurs neutres comme `[]`, `null`, `STANDARD` ou `UNKNOWN`.
+
+## Validation
+
+Avant restauration, le parseur vérifie:
+
+- JSON lisible;
+- version supportée;
+- tableaux attendus;
+- types scalaires des champs;
+- identifiants entiers positifs;
+- montants attendus positifs;
+- dates journalières au format `YYYY-MM-DD`;
+- références entre comptes, catégories, budgets, récurrences et transactions;
+- cohérence des transferts internes avec une jambe `OUT`, une jambe `IN` et des comptes pairs croisés;
+- absence de doublons d’identifiants dans chaque collection.
+
+Un fichier invalide échoue avant l’écran de prévisualisation quand l’erreur est structurelle. Les erreurs indiquent le champ ou la relation en cause quand c’est possible.
+
+## Garanties
+
+- Un export JSON courant peut être relu par l’application.
+- Les backups `2` et `3` restent acceptés.
+- Un format corrompu ou incohérent est refusé avant restauration.
+- Les profils fiscaux et les métadonnées fiscales sont inclus dans le snapshot et réappliqués pendant la restauration.
+
+## Limites
+
+- Les versions antérieures à `2` ne sont pas supportées.
+- Les champs inconnus sont ignorés.
+- La restauration est une opération applicative côté renderer, pas une transaction SQLite globale.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "electron-vue-prisma-template",
-  "version": "0.1.0",
+  "name": "budget",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "electron-vue-prisma-template",
-      "version": "0.1.0",
-      "hasInstallScript": true,
+      "name": "budget",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@intlify/devtools-types": "^11.3.2",

--- a/src/composables/useJsonBackup.ts
+++ b/src/composables/useJsonBackup.ts
@@ -28,6 +28,10 @@ function absAmount(value: number | null | undefined) {
     return Math.abs(value ?? 0)
 }
 
+function firstValidationError(validation: BackupValidationResult) {
+    return validation.warnings[0] || tr('notices.jsonInvalid')
+}
+
 export function useJsonBackup(options: UseJsonBackupOptions) {
     const restorePreviewOpen = ref(false)
     const restorePreviewPath = ref<string | null>(null)
@@ -83,6 +87,10 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
         for (const account of [...options.accounts.value]) {
             await window.db.account.delete(account.id)
         }
+
+        for (const taxProfile of [...(options.taxProfiles?.value || [])]) {
+            await window.db.taxProfile.delete(taxProfile.id)
+        }
     }
 
     async function beginRestoreBackupJson() {
@@ -98,6 +106,10 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
         try {
             const snapshot = parseBudgetBackup(result.content)
             const validation = validateBackupSnapshot(snapshot)
+
+            if (!validation.ok) {
+                throw new Error(firstValidationError(validation))
+            }
 
             restorePreviewSnapshot.value = snapshot
             restorePreviewValidation.value = validation
@@ -118,6 +130,29 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
             && candidate.transferDirection === 'IN'
             && candidate.id !== transaction.id,
         ) || null
+    }
+
+    async function restoreAccountTaxMetadata(createdId: number, account: BudgetBackupSnapshot['data']['accounts'][number]) {
+        await window.db.taxMetadata.updateAccount(createdId, {
+            institutionCountry: account.institutionCountry ?? null,
+            institutionRegion: account.institutionRegion ?? null,
+            taxReportingType: account.taxReportingType ?? 'STANDARD',
+            openedAt: account.openedAt ?? null,
+            closedAt: account.closedAt ?? null,
+        })
+    }
+
+    async function restoreTransactionTaxMetadata(createdId: number, transaction: BudgetBackupTransaction) {
+        await window.db.taxMetadata.updateTransaction(createdId, {
+            taxCategory: transaction.taxCategory ?? null,
+            taxSourceCountry: transaction.taxSourceCountry ?? null,
+            taxSourceRegion: transaction.taxSourceRegion ?? null,
+            taxTreatment: transaction.taxTreatment ?? 'UNKNOWN',
+            taxWithheldAmount: transaction.taxWithheldAmount ?? null,
+            taxWithheldCurrency: transaction.taxWithheldCurrency ?? null,
+            taxWithheldCountry: transaction.taxWithheldCountry ?? null,
+            taxDocumentRef: transaction.taxDocumentRef ?? null,
+        })
     }
 
     async function restoreTransactions(
@@ -152,7 +187,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
 
                 if (mappedTargetAccountId) {
                     const referenceRow = incomingPeer || transaction
-                    await window.db.transaction.create({
+                    const created = await window.db.transaction.create({
                         label: transaction.label,
                         amount: absAmount(referenceRow.amount),
                         sourceAmount: absAmount(transaction.sourceAmount ?? transaction.amount),
@@ -168,6 +203,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
                         categoryId: null,
                         transferTargetAccountId: mappedTargetAccountId,
                     })
+                    await restoreTransactionTaxMetadata(created.id, transaction)
 
                     if (transaction.transferGroup) {
                         restoredTransferGroups.add(transaction.transferGroup)
@@ -176,7 +212,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
                 }
             }
 
-            await window.db.transaction.create({
+            const created = await window.db.transaction.create({
                 label: transaction.label,
                 amount: absAmount(transaction.amount),
                 sourceAmount: transaction.sourceAmount == null ? null : absAmount(transaction.sourceAmount),
@@ -191,6 +227,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
                 accountId: mappedAccountId,
                 categoryId: transaction.kind === 'TRANSFER' ? null : mappedCategoryId,
             })
+            await restoreTransactionTaxMetadata(created.id, transaction)
         }
     }
 
@@ -199,6 +236,11 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
 
         try {
             const snapshot = restorePreviewSnapshot.value
+            const validation = validateBackupSnapshot(snapshot)
+
+            if (!validation.ok) {
+                throw new Error(firstValidationError(validation))
+            }
 
             await replaceAllData()
 
@@ -212,6 +254,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
                     currency: account.currency,
                     description: account.description,
                 })
+                await restoreAccountTaxMetadata(created.id, account)
                 accountIdMap.set(account.id, created.id)
             }
 
@@ -223,6 +266,15 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
                     description: category.description,
                 })
                 categoryIdMap.set(category.id, created.id)
+            }
+
+            for (const taxProfile of snapshot.data.taxProfiles || []) {
+                await window.db.taxProfile.create({
+                    year: taxProfile.year,
+                    residenceCountry: taxProfile.residenceCountry,
+                    residenceRegion: taxProfile.residenceRegion,
+                    currency: taxProfile.currency,
+                })
             }
 
             for (const budgetTarget of snapshot.data.budgetTargets) {

--- a/src/test/utils/jsonBackup.test.ts
+++ b/src/test/utils/jsonBackup.test.ts
@@ -1,8 +1,195 @@
 import {describe, expect, it} from 'vitest'
-import {createBudgetBackupSnapshot, parseBudgetBackup, serializeBudgetBackup} from '../../utils/jsonBackup'
+import {
+    BUDGET_BACKUP_FORMAT_VERSION,
+    createBudgetBackupSnapshot,
+    parseBudgetBackup,
+    serializeBudgetBackup,
+} from '../../utils/jsonBackup'
 
-describe('json backup utils', () => {
-    it('creates and parses a valid v4 snapshot with budgets, recurring templates, transfer metadata and tax metadata', () => {
+function validBackup(version = BUDGET_BACKUP_FORMAT_VERSION) {
+    return {
+        kind: 'budget-backup',
+        version,
+        exportedAt: '2026-04-24T10:00:00.000Z',
+        data: {
+            accounts: [
+                {
+                    id: 1,
+                    name: 'Main',
+                    type: 'BANK',
+                    currency: 'CAD',
+                    description: null,
+                    institutionCountry: 'CA',
+                    institutionRegion: 'QC',
+                    taxReportingType: 'BANK',
+                    openedAt: null,
+                    closedAt: null,
+                },
+                {
+                    id: 2,
+                    name: 'Savings',
+                    type: 'SAVINGS',
+                    currency: 'CAD',
+                    description: null,
+                    institutionCountry: 'CA',
+                    institutionRegion: 'QC',
+                    taxReportingType: 'BANK',
+                    openedAt: null,
+                    closedAt: null,
+                },
+            ],
+            categories: [
+                {id: 10, name: 'Groceries', kind: 'EXPENSE', color: '#000000', description: null},
+            ],
+            budgetTargets: [
+                {
+                    id: 20,
+                    name: 'Food',
+                    amount: 500,
+                    period: 'MONTHLY',
+                    startDate: '2026-04-01',
+                    endDate: null,
+                    currency: 'CAD',
+                    isActive: true,
+                    note: null,
+                    categoryId: 10,
+                },
+            ],
+            recurringTemplates: [],
+            transactions: [
+                {
+                    id: 100,
+                    label: 'Groceries',
+                    amount: 25,
+                    sourceAmount: 25,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: '2026-04-10',
+                    kind: 'EXPENSE',
+                    date: '2026-04-10',
+                    note: null,
+                    taxCategory: null,
+                    taxSourceCountry: null,
+                    taxSourceRegion: null,
+                    taxTreatment: 'UNKNOWN',
+                    taxWithheldAmount: null,
+                    taxWithheldCurrency: null,
+                    taxWithheldCountry: null,
+                    taxDocumentRef: null,
+                    accountId: 1,
+                    categoryId: 10,
+                    transferGroup: null,
+                    transferDirection: null,
+                    transferPeerAccountId: null,
+                },
+                {
+                    id: 101,
+                    label: 'Move to savings',
+                    amount: 50,
+                    sourceAmount: 50,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: '2026-04-11',
+                    kind: 'TRANSFER',
+                    date: '2026-04-11',
+                    note: null,
+                    taxCategory: 'TRANSFER',
+                    taxSourceCountry: 'CA',
+                    taxSourceRegion: 'QC',
+                    taxTreatment: 'NOT_TAXABLE',
+                    taxWithheldAmount: null,
+                    taxWithheldCurrency: null,
+                    taxWithheldCountry: null,
+                    taxDocumentRef: 'transfer-note',
+                    accountId: 1,
+                    categoryId: null,
+                    transferGroup: 'grp-1',
+                    transferDirection: 'OUT',
+                    transferPeerAccountId: 2,
+                },
+                {
+                    id: 102,
+                    label: 'Move to savings',
+                    amount: 50,
+                    sourceAmount: 50,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: '2026-04-11',
+                    kind: 'TRANSFER',
+                    date: '2026-04-11',
+                    note: null,
+                    taxCategory: 'TRANSFER',
+                    taxSourceCountry: 'CA',
+                    taxSourceRegion: 'QC',
+                    taxTreatment: 'NOT_TAXABLE',
+                    taxWithheldAmount: null,
+                    taxWithheldCurrency: null,
+                    taxWithheldCountry: null,
+                    taxDocumentRef: 'transfer-note',
+                    accountId: 2,
+                    categoryId: null,
+                    transferGroup: 'grp-1',
+                    transferDirection: 'IN',
+                    transferPeerAccountId: 1,
+                },
+            ],
+            taxProfiles: [
+                {
+                    id: 200,
+                    year: 2026,
+                    residenceCountry: 'CA',
+                    residenceRegion: 'QC',
+                    currency: 'CAD',
+                },
+            ],
+        },
+    }
+}
+
+describe('jsonBackup format', () => {
+    it('parses and serializes the current explicit backup version', () => {
+        const parsed = parseBudgetBackup(JSON.stringify(validBackup()))
+        const serialized = serializeBudgetBackup(parsed)
+
+        expect(parsed.version).toBe(BUDGET_BACKUP_FORMAT_VERSION)
+        expect(parsed.data.accounts).toHaveLength(2)
+        expect(parsed.data.taxProfiles).toHaveLength(1)
+        expect(serialized).toContain('"kind": "budget-backup"')
+        expect(serialized).toContain('"version": 4')
+    })
+
+    it('normalizes a supported legacy version without tax metadata', () => {
+        const legacy = validBackup(2)
+        delete (legacy.data as any).taxProfiles
+        delete (legacy.data.accounts[0] as any).institutionCountry
+        delete (legacy.data.accounts[0] as any).institutionRegion
+        delete (legacy.data.accounts[0] as any).taxReportingType
+        delete (legacy.data.accounts[0] as any).openedAt
+        delete (legacy.data.accounts[0] as any).closedAt
+        delete (legacy.data.transactions[0] as any).taxCategory
+        delete (legacy.data.transactions[0] as any).taxSourceCountry
+        delete (legacy.data.transactions[0] as any).taxSourceRegion
+        delete (legacy.data.transactions[0] as any).taxTreatment
+        delete (legacy.data.transactions[0] as any).taxWithheldAmount
+        delete (legacy.data.transactions[0] as any).taxWithheldCurrency
+        delete (legacy.data.transactions[0] as any).taxWithheldCountry
+        delete (legacy.data.transactions[0] as any).taxDocumentRef
+
+        const parsed = parseBudgetBackup(JSON.stringify(legacy))
+
+        expect(parsed.version).toBe(2)
+        expect(parsed.data.taxProfiles).toEqual([])
+        expect(parsed.data.accounts[0].taxReportingType).toBe('STANDARD')
+        expect(parsed.data.transactions[0].taxTreatment).toBe('UNKNOWN')
+    })
+
+    it('creates and parses a valid v4 snapshot with backup helper', () => {
         const snapshot = createBudgetBackupSnapshot(
             [{
                 id: 1,
@@ -17,41 +204,11 @@ describe('json backup utils', () => {
                 closedAt: null,
             }],
             [{id: 2, name: 'Food', kind: 'EXPENSE', color: '#ff00aa', description: null}],
-            [{
-                id: 10,
-                name: 'Budget food',
-                amount: 400,
-                period: 'MONTHLY',
-                startDate: '2026-04-01',
-                endDate: null,
-                currency: 'CAD',
-                isActive: true,
-                note: null,
-                categoryId: 2,
-            }],
-            [{
-                id: 20,
-                label: 'Spotify',
-                sourceAmount: 12,
-                sourceCurrency: 'CAD',
-                accountAmount: 12,
-                conversionMode: 'NONE',
-                exchangeRate: 1,
-                exchangeProvider: 'ACCOUNT',
-                kind: 'EXPENSE',
-                note: null,
-                frequency: 'MONTHLY',
-                intervalCount: 1,
-                startDate: '2026-04-01',
-                nextOccurrenceDate: '2026-05-01',
-                endDate: null,
-                isActive: true,
-                accountId: 1,
-                categoryId: 2,
-            }],
+            [],
+            [],
             [{
                 id: 3,
-                label: 'Move to savings',
+                label: 'Groceries',
                 amount: 42,
                 sourceAmount: 42,
                 sourceCurrency: 'CAD',
@@ -59,22 +216,22 @@ describe('json backup utils', () => {
                 exchangeRate: 1,
                 exchangeProvider: 'ACCOUNT',
                 exchangeDate: '2026-04-20',
-                kind: 'TRANSFER',
+                kind: 'EXPENSE',
                 date: '2026-04-20',
                 note: null,
-                taxCategory: 'TRANSFER',
+                taxCategory: 'OTHER',
                 taxSourceCountry: 'CA',
                 taxSourceRegion: 'QC',
-                taxTreatment: 'NOT_TAXABLE',
+                taxTreatment: 'TAXABLE_NO_WITHHOLDING',
                 taxWithheldAmount: null,
                 taxWithheldCurrency: null,
                 taxWithheldCountry: null,
-                taxDocumentRef: 'internal-transfer-note',
+                taxDocumentRef: 'receipt-123',
                 accountId: 1,
-                categoryId: null,
-                transferGroup: 'grp-1',
-                transferDirection: 'OUT',
-                transferPeerAccountId: 99,
+                categoryId: 2,
+                transferGroup: null,
+                transferDirection: null,
+                transferPeerAccountId: null,
             }],
             [{
                 id: 50,
@@ -85,63 +242,44 @@ describe('json backup utils', () => {
             }],
         )
 
-        const serialized = serializeBudgetBackup(snapshot)
-        const parsed = parseBudgetBackup(serialized)
+        const parsed = parseBudgetBackup(serializeBudgetBackup(snapshot))
 
         expect(parsed.kind).toBe('budget-backup')
         expect(parsed.version).toBe(4)
-        expect(parsed.data.accounts).toHaveLength(1)
         expect(parsed.data.accounts[0].institutionCountry).toBe('CA')
-        expect(parsed.data.accounts[0].institutionRegion).toBe('QC')
-        expect(parsed.data.accounts[0].taxReportingType).toBe('BANK')
-        expect(parsed.data.categories).toHaveLength(1)
-        expect(parsed.data.budgetTargets).toHaveLength(1)
-        expect(parsed.data.recurringTemplates).toHaveLength(1)
-        expect(parsed.data.transactions).toHaveLength(1)
-        expect(parsed.data.transactions[0].transferGroup).toBe('grp-1')
-        expect(parsed.data.transactions[0].transferDirection).toBe('OUT')
-        expect(parsed.data.transactions[0].transferPeerAccountId).toBe(99)
-        expect(parsed.data.transactions[0].taxTreatment).toBe('NOT_TAXABLE')
-        expect(parsed.data.transactions[0].taxDocumentRef).toBe('internal-transfer-note')
-        expect(parsed.data.taxProfiles).toHaveLength(1)
+        expect(parsed.data.transactions[0].taxTreatment).toBe('TAXABLE_NO_WITHHOLDING')
+        expect(parsed.data.transactions[0].taxDocumentRef).toBe('receipt-123')
         expect(parsed.data.taxProfiles?.[0].residenceRegion).toBe('QC')
     })
 
-    it('accepts legacy version 2 snapshots', () => {
-        const parsed = parseBudgetBackup(JSON.stringify({
-            kind: 'budget-backup',
-            version: 2,
-            exportedAt: '2026-04-20T00:00:00.000Z',
-            data: {
-                accounts: [],
-                categories: [],
-                budgetTargets: [],
-                recurringTemplates: [],
-                transactions: [],
-            },
-        }))
+    it('rejects a corrupted structure before restore', () => {
+        const corrupted = validBackup()
+        delete (corrupted.data.transactions[0] as any).accountId
 
-        expect(parsed.version).toBe(2)
+        expect(() => parseBudgetBackup(JSON.stringify(corrupted)))
+            .toThrow('data.transactions[0].accountId')
     })
 
-    it('accepts legacy version 3 snapshots', () => {
-        const parsed = parseBudgetBackup(JSON.stringify({
-            kind: 'budget-backup',
-            version: 3,
-            exportedAt: '2026-04-20T00:00:00.000Z',
-            data: {
-                accounts: [],
-                categories: [],
-                budgetTargets: [],
-                recurringTemplates: [],
-                transactions: [],
-            },
-        }))
+    it('rejects dangling references before restore', () => {
+        const dangling = validBackup()
+        dangling.data.budgetTargets[0].categoryId = 999
 
-        expect(parsed.version).toBe(3)
+        expect(() => parseBudgetBackup(JSON.stringify(dangling)))
+            .toThrow('catégorie absente')
     })
 
-    it('rejects invalid snapshot', () => {
-        expect(() => parseBudgetBackup('{"kind":"wrong"}')).toThrow()
+    it('rejects unsupported backup versions clearly', () => {
+        const unsupported = validBackup(99)
+
+        expect(() => parseBudgetBackup(JSON.stringify(unsupported)))
+            .toThrow('Version de backup JSON non supportée')
+    })
+
+    it('rejects incomplete transfer groups', () => {
+        const corrupted = validBackup()
+        corrupted.data.transactions = corrupted.data.transactions.filter((transaction) => transaction.id !== 102)
+
+        expect(() => parseBudgetBackup(JSON.stringify(corrupted)))
+            .toThrow('exactement deux jambes')
     })
 })

--- a/src/utils/importValidation.ts
+++ b/src/utils/importValidation.ts
@@ -1,5 +1,5 @@
 import type {CsvRecord} from './csv'
-import type {BudgetBackupSnapshot, EntityType} from '../types/budget'
+import type {BudgetBackupSnapshot, BudgetBackupTransaction, EntityType} from '../types/budget'
 
 export interface ImportPreviewSummary {
     totalRows: number
@@ -68,14 +68,57 @@ export interface BackupValidationResult {
         budgetTargets: number
         recurringTemplates: number
         transactions: number
+        taxProfiles: number
+    }
+}
+
+function addDuplicateIdWarnings(rows: {id: number; name?: string; label?: string}[], entityLabel: string, warnings: string[]) {
+    const seen = new Map<number, string>()
+
+    for (const row of rows) {
+        const label = row.name || row.label || `#${row.id}`
+        const existing = seen.get(row.id)
+        if (existing) {
+            warnings.push(`${entityLabel} contient un identifiant dupliqué (${row.id}) : ${existing} / ${label}.`)
+        } else {
+            seen.set(row.id, label)
+        }
     }
 }
 
 export function validateBackupSnapshot(snapshot: BudgetBackupSnapshot): BackupValidationResult {
     const warnings: string[] = []
+    const taxProfiles = snapshot.data.taxProfiles || []
+
+    addDuplicateIdWarnings(snapshot.data.accounts, 'Comptes', warnings)
+    addDuplicateIdWarnings(snapshot.data.categories, 'Catégories', warnings)
+    addDuplicateIdWarnings(snapshot.data.budgetTargets, 'Budgets', warnings)
+    addDuplicateIdWarnings(snapshot.data.recurringTemplates, 'Récurrences', warnings)
+    addDuplicateIdWarnings(snapshot.data.transactions, 'Transactions', warnings)
+    addDuplicateIdWarnings(taxProfiles, 'Profils fiscaux', warnings)
 
     const accountIds = new Set(snapshot.data.accounts.map((account) => account.id))
     const categoryIds = new Set(snapshot.data.categories.map((category) => category.id))
+
+    for (const account of snapshot.data.accounts) {
+        if (!account.name.trim()) {
+            warnings.push('Un compte a un nom vide.')
+        }
+
+        if (!account.currency.trim()) {
+            warnings.push(`Compte "${account.name}" sans devise.`)
+        }
+
+        if (account.openedAt && account.closedAt && new Date(account.closedAt).getTime() < new Date(account.openedAt).getTime()) {
+            warnings.push(`Compte "${account.name}" : la date de fermeture précède la date d'ouverture.`)
+        }
+    }
+
+    for (const category of snapshot.data.categories) {
+        if (!category.name.trim()) {
+            warnings.push('Une catégorie a un nom vide.')
+        }
+    }
 
     for (const budgetTarget of snapshot.data.budgetTargets) {
         if (!categoryIds.has(budgetTarget.categoryId)) {
@@ -109,7 +152,7 @@ export function validateBackupSnapshot(snapshot: BudgetBackupSnapshot): BackupVa
         }
     }
 
-    const transferGroups = new Map<string, number>()
+    const transferGroups = new Map<string, BudgetBackupTransaction[]>()
 
     for (const transaction of snapshot.data.transactions) {
         if (!accountIds.has(transaction.accountId)) {
@@ -137,13 +180,40 @@ export function validateBackupSnapshot(snapshot: BudgetBackupSnapshot): BackupVa
         }
 
         if (transaction.transferGroup) {
-            transferGroups.set(transaction.transferGroup, (transferGroups.get(transaction.transferGroup) || 0) + 1)
+            const rows = transferGroups.get(transaction.transferGroup) || []
+            rows.push(transaction)
+            transferGroups.set(transaction.transferGroup, rows)
         }
     }
 
-    for (const [group, count] of transferGroups.entries()) {
-        if (count === 1) {
-            warnings.push(`Le transfert interne ${group} ne contient qu'une seule jambe.`)
+    for (const [group, rows] of transferGroups.entries()) {
+        const outgoing = rows.filter((transaction) => transaction.transferDirection === 'OUT')
+        const incoming = rows.filter((transaction) => transaction.transferDirection === 'IN')
+
+        if (rows.length !== 2) {
+            warnings.push(`Le transfert interne ${group} doit contenir exactement deux jambes.`)
+        } else if (outgoing.length !== 1 || incoming.length !== 1) {
+            warnings.push(`Le transfert interne ${group} doit contenir une jambe OUT et une jambe IN.`)
+        } else if (
+            outgoing[0].accountId === incoming[0].accountId ||
+            outgoing[0].transferPeerAccountId !== incoming[0].accountId ||
+            incoming[0].transferPeerAccountId !== outgoing[0].accountId
+        ) {
+            warnings.push(`Le transfert interne ${group} est incohérent.`)
+        }
+    }
+
+    for (const profile of taxProfiles) {
+        if (!(profile.year >= 1900 && profile.year <= 2200)) {
+            warnings.push(`Profil fiscal ${profile.id} avec année invalide (${profile.year}).`)
+        }
+
+        if (!profile.residenceCountry.trim()) {
+            warnings.push(`Profil fiscal ${profile.id} sans pays de résidence.`)
+        }
+
+        if (!profile.currency.trim()) {
+            warnings.push(`Profil fiscal ${profile.id} sans devise.`)
         }
     }
 
@@ -156,6 +226,7 @@ export function validateBackupSnapshot(snapshot: BudgetBackupSnapshot): BackupVa
             budgetTargets: snapshot.data.budgetTargets.length,
             recurringTemplates: snapshot.data.recurringTemplates.length,
             transactions: snapshot.data.transactions.length,
+            taxProfiles: taxProfiles.length,
         },
     }
 }

--- a/src/utils/jsonBackup.ts
+++ b/src/utils/jsonBackup.ts
@@ -1,13 +1,530 @@
 import type {
     Account,
+    AccountTaxReportingType,
+    AccountType,
+    BudgetBackupAccount,
+    BudgetBackupBudgetTarget,
+    BudgetBackupCategory,
+    BudgetBackupRecurringTransactionTemplate,
     BudgetBackupSnapshot,
+    BudgetBackupTaxProfile,
+    BudgetBackupTransaction,
     BudgetTarget,
+    BudgetPeriod,
     Category,
+    ConversionMode,
+    RecurringFrequency,
     RecurringTransactionTemplate,
+    TaxIncomeCategory,
     TaxProfile,
+    TaxTreatment,
     Transaction,
+    TransactionKind,
+    TransferDirection,
 } from '../types/budget'
 import {toDateOnly} from './date'
+
+export const BUDGET_BACKUP_KIND = 'budget-backup'
+export const BUDGET_BACKUP_FORMAT_VERSION = 4
+export const SUPPORTED_BUDGET_BACKUP_VERSIONS = [2, 3, 4] as const
+
+export type BudgetBackupFormatVersion = typeof SUPPORTED_BUDGET_BACKUP_VERSIONS[number]
+
+const INVALID_BACKUP_MESSAGE = 'Le fichier JSON ne correspond pas à un backup budget valide.'
+
+const ACCOUNT_TYPES = ['CASH', 'BANK', 'SAVINGS', 'CREDIT', 'INVESTMENT', 'OTHER'] as const
+const ACCOUNT_TAX_REPORTING_TYPES = ['STANDARD', 'BANK', 'CASH', 'BROKERAGE', 'CRYPTO', 'LIFE_INSURANCE', 'RETIREMENT', 'LOAN', 'OTHER'] as const
+const TRANSACTION_KINDS = ['INCOME', 'EXPENSE', 'TRANSFER'] as const
+const CONVERSION_MODES = ['NONE', 'MANUAL', 'AUTOMATIC'] as const
+const TRANSFER_DIRECTIONS = ['OUT', 'IN'] as const
+const BUDGET_PERIODS = ['MONTHLY', 'YEARLY', 'CUSTOM'] as const
+const RECURRING_FREQUENCIES = ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'] as const
+const TAX_INCOME_CATEGORIES = ['EMPLOYMENT', 'BUSINESS', 'INTEREST', 'DIVIDEND', 'CAPITAL_GAIN', 'RENTAL', 'PENSION', 'BENEFIT', 'GIFT', 'REFUND', 'TRANSFER', 'OTHER'] as const
+const TAX_TREATMENTS = ['UNKNOWN', 'NOT_TAXABLE', 'TAXABLE_NO_WITHHOLDING', 'TAX_WITHHELD_AT_SOURCE', 'FOREIGN_TAX_CREDIT_CANDIDATE', 'TREATY_EXEMPT_CANDIDATE', 'REVIEW_REQUIRED'] as const
+
+export class BudgetBackupParseError extends Error {
+    constructor(message = INVALID_BACKUP_MESSAGE) {
+        super(message)
+        this.name = 'BudgetBackupParseError'
+    }
+}
+
+function fail(message = INVALID_BACKUP_MESSAGE): never {
+    throw new BudgetBackupParseError(message)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requireRecord(value: unknown, path: string): Record<string, unknown> {
+    if (!isRecord(value)) {
+        fail(`${path} doit être un objet.`)
+    }
+    return value
+}
+
+function requireArray(value: unknown, path: string): unknown[] {
+    if (!Array.isArray(value)) {
+        fail(`${path} doit être un tableau.`)
+    }
+    return value
+}
+
+function requireString(value: unknown, path: string): string {
+    if (typeof value !== 'string') {
+        fail(`${path} doit être une chaîne de caractères.`)
+    }
+    return value
+}
+
+function requireNonEmptyString(value: unknown, path: string): string {
+    const normalized = requireString(value, path).trim()
+    if (!normalized) {
+        fail(`${path} ne peut pas être vide.`)
+    }
+    return normalized
+}
+
+function requireNullableString(value: unknown, path: string): string | null {
+    if (value === null) return null
+    return requireString(value, path)
+}
+
+function optionalNullableString(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: string | null = null,
+): string | null {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+    return requireString(record[key], `${path}.${key}`)
+}
+
+function requireFiniteNumber(value: unknown, path: string): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        fail(`${path} doit être un nombre fini.`)
+    }
+    return value
+}
+
+function requirePositiveNumber(value: unknown, path: string): number {
+    const parsed = requireFiniteNumber(value, path)
+    if (parsed <= 0) {
+        fail(`${path} doit être strictement positif.`)
+    }
+    return parsed
+}
+
+function requireNonNegativeNumber(value: unknown, path: string): number {
+    const parsed = requireFiniteNumber(value, path)
+    if (parsed < 0) {
+        fail(`${path} doit être positif ou nul.`)
+    }
+    return parsed
+}
+
+function requireIntegerId(value: unknown, path: string): number {
+    const parsed = requireFiniteNumber(value, path)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        fail(`${path} doit être un identifiant entier positif.`)
+    }
+    return parsed
+}
+
+function optionalNullablePositiveNumber(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: number | null = null,
+): number | null {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+    return requirePositiveNumber(record[key], `${path}.${key}`)
+}
+
+function optionalNullableNonNegativeNumber(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: number | null = null,
+): number | null {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+    return requireNonNegativeNumber(record[key], `${path}.${key}`)
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+    if (typeof value !== 'boolean') {
+        fail(`${path} doit être un booléen.`)
+    }
+    return value
+}
+
+function optionalBoolean(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: boolean,
+): boolean {
+    if (!(key in record) || record[key] === undefined) {
+        return fallback
+    }
+    return requireBoolean(record[key], `${path}.${key}`)
+}
+
+function requireOneOf<T extends readonly string[]>(value: unknown, path: string, allowed: T): T[number] {
+    if (typeof value !== 'string' || !(allowed as readonly string[]).includes(value)) {
+        fail(`${path} contient une valeur non supportée.`)
+    }
+    return value as T[number]
+}
+
+function optionalOneOf<T extends readonly string[]>(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    allowed: T,
+    fallback: T[number],
+): T[number] {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+    return requireOneOf(record[key], `${path}.${key}`, allowed)
+}
+
+function requireDateOnly(value: unknown, path: string): string {
+    const date = requireString(value, path)
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        fail(`${path} doit être une date au format YYYY-MM-DD.`)
+    }
+    return date
+}
+
+function requireNullableDateOnly(value: unknown, path: string): string | null {
+    if (value === null) return null
+    return requireDateOnly(value, path)
+}
+
+function optionalNullableDateOnly(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: string | null = null,
+): string | null {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+    return requireDateOnly(record[key], `${path}.${key}`)
+}
+
+function optionalNullableIsoDate(
+    record: Record<string, unknown>,
+    key: string,
+    path: string,
+    fallback: string | null = null,
+): string | null {
+    if (!(key in record) || record[key] === undefined || record[key] === null) {
+        return fallback
+    }
+
+    const date = requireString(record[key], `${path}.${key}`)
+    if (Number.isNaN(new Date(date).getTime())) {
+        fail(`${path}.${key} doit être une date valide.`)
+    }
+    return date
+}
+
+function parseVersion(value: unknown): BudgetBackupFormatVersion {
+    if (typeof value !== 'number' || !Number.isInteger(value)) {
+        fail('Le backup JSON doit déclarer une version numérique explicite.')
+    }
+
+    if (!(SUPPORTED_BUDGET_BACKUP_VERSIONS as readonly number[]).includes(value)) {
+        fail(`Version de backup JSON non supportée (${value}). Versions supportées : ${SUPPORTED_BUDGET_BACKUP_VERSIONS.join(', ')}.`)
+    }
+
+    return value as BudgetBackupFormatVersion
+}
+
+function requireExportedAt(value: unknown): string {
+    const exportedAt = requireString(value, 'exportedAt')
+    if (Number.isNaN(new Date(exportedAt).getTime())) {
+        fail('exportedAt doit être une date valide.')
+    }
+    return exportedAt
+}
+
+function ensureUniqueIds(rows: {id: number}[], label: string) {
+    const seen = new Set<number>()
+    for (const row of rows) {
+        if (seen.has(row.id)) {
+            fail(`${label} contient un identifiant dupliqué (${row.id}).`)
+        }
+        seen.add(row.id)
+    }
+}
+
+function normalizeAccount(value: unknown, index: number): BudgetBackupAccount {
+    const path = `data.accounts[${index}]`
+    const account = requireRecord(value, path)
+
+    return {
+        id: requireIntegerId(account.id, `${path}.id`),
+        name: requireNonEmptyString(account.name, `${path}.name`),
+        type: requireOneOf(account.type, `${path}.type`, ACCOUNT_TYPES) as AccountType,
+        currency: requireNonEmptyString(account.currency, `${path}.currency`).toUpperCase(),
+        description: requireNullableString(account.description, `${path}.description`),
+        institutionCountry: optionalNullableString(account, 'institutionCountry', path),
+        institutionRegion: optionalNullableString(account, 'institutionRegion', path),
+        taxReportingType: optionalOneOf(account, 'taxReportingType', path, ACCOUNT_TAX_REPORTING_TYPES, 'STANDARD') as AccountTaxReportingType,
+        openedAt: optionalNullableIsoDate(account, 'openedAt', path),
+        closedAt: optionalNullableIsoDate(account, 'closedAt', path),
+    }
+}
+
+function normalizeCategory(value: unknown, index: number): BudgetBackupCategory {
+    const path = `data.categories[${index}]`
+    const category = requireRecord(value, path)
+
+    return {
+        id: requireIntegerId(category.id, `${path}.id`),
+        name: requireNonEmptyString(category.name, `${path}.name`),
+        kind: requireOneOf(category.kind, `${path}.kind`, TRANSACTION_KINDS) as TransactionKind,
+        color: requireNullableString(category.color, `${path}.color`),
+        description: requireNullableString(category.description, `${path}.description`),
+    }
+}
+
+function normalizeBudgetTarget(value: unknown, index: number): BudgetBackupBudgetTarget {
+    const path = `data.budgetTargets[${index}]`
+    const budgetTarget = requireRecord(value, path)
+
+    return {
+        id: requireIntegerId(budgetTarget.id, `${path}.id`),
+        name: requireNonEmptyString(budgetTarget.name, `${path}.name`),
+        amount: requirePositiveNumber(budgetTarget.amount, `${path}.amount`),
+        period: requireOneOf(budgetTarget.period, `${path}.period`, BUDGET_PERIODS) as BudgetPeriod,
+        startDate: requireDateOnly(budgetTarget.startDate, `${path}.startDate`),
+        endDate: requireNullableDateOnly(budgetTarget.endDate, `${path}.endDate`),
+        currency: requireNonEmptyString(budgetTarget.currency, `${path}.currency`).toUpperCase(),
+        isActive: optionalBoolean(budgetTarget, 'isActive', path, true),
+        note: requireNullableString(budgetTarget.note, `${path}.note`),
+        categoryId: requireIntegerId(budgetTarget.categoryId, `${path}.categoryId`),
+    }
+}
+
+function normalizeRecurringTemplate(value: unknown, index: number): BudgetBackupRecurringTransactionTemplate {
+    const path = `data.recurringTemplates[${index}]`
+    const template = requireRecord(value, path)
+    const sourceAmount = requirePositiveNumber(template.sourceAmount, `${path}.sourceAmount`)
+
+    return {
+        id: requireIntegerId(template.id, `${path}.id`),
+        label: requireNonEmptyString(template.label, `${path}.label`),
+        sourceAmount,
+        sourceCurrency: requireNonEmptyString(template.sourceCurrency, `${path}.sourceCurrency`).toUpperCase(),
+        accountAmount: optionalNullablePositiveNumber(template, 'accountAmount', path),
+        conversionMode: optionalOneOf(template, 'conversionMode', path, CONVERSION_MODES, 'NONE') as ConversionMode,
+        exchangeRate: optionalNullablePositiveNumber(template, 'exchangeRate', path, 1),
+        exchangeProvider: optionalNullableString(template, 'exchangeProvider', path, 'ACCOUNT'),
+        kind: requireOneOf(template.kind, `${path}.kind`, TRANSACTION_KINDS) as TransactionKind,
+        note: requireNullableString(template.note, `${path}.note`),
+        frequency: requireOneOf(template.frequency, `${path}.frequency`, RECURRING_FREQUENCIES) as RecurringFrequency,
+        intervalCount: requireIntegerId(template.intervalCount, `${path}.intervalCount`),
+        startDate: requireDateOnly(template.startDate, `${path}.startDate`),
+        nextOccurrenceDate: requireDateOnly(template.nextOccurrenceDate, `${path}.nextOccurrenceDate`),
+        endDate: requireNullableDateOnly(template.endDate, `${path}.endDate`),
+        isActive: optionalBoolean(template, 'isActive', path, true),
+        accountId: requireIntegerId(template.accountId, `${path}.accountId`),
+        categoryId: template.categoryId == null ? null : requireIntegerId(template.categoryId, `${path}.categoryId`),
+    }
+}
+
+function normalizeTransaction(value: unknown, index: number): BudgetBackupTransaction {
+    const path = `data.transactions[${index}]`
+    const transaction = requireRecord(value, path)
+    const amount = requirePositiveNumber(transaction.amount, `${path}.amount`)
+    const date = requireDateOnly(transaction.date, `${path}.date`)
+
+    return {
+        id: requireIntegerId(transaction.id, `${path}.id`),
+        label: requireNonEmptyString(transaction.label, `${path}.label`),
+        amount,
+        sourceAmount: optionalNullablePositiveNumber(transaction, 'sourceAmount', path, amount),
+        sourceCurrency: optionalNullableString(transaction, 'sourceCurrency', path),
+        conversionMode: optionalOneOf(transaction, 'conversionMode', path, CONVERSION_MODES, 'NONE') as ConversionMode,
+        exchangeRate: optionalNullablePositiveNumber(transaction, 'exchangeRate', path, 1),
+        exchangeProvider: optionalNullableString(transaction, 'exchangeProvider', path, 'ACCOUNT'),
+        exchangeDate: optionalNullableDateOnly(transaction, 'exchangeDate', path, date),
+        kind: requireOneOf(transaction.kind, `${path}.kind`, TRANSACTION_KINDS) as TransactionKind,
+        date,
+        note: requireNullableString(transaction.note, `${path}.note`),
+        taxCategory: transaction.taxCategory == null
+            ? null
+            : requireOneOf(transaction.taxCategory, `${path}.taxCategory`, TAX_INCOME_CATEGORIES) as TaxIncomeCategory,
+        taxSourceCountry: optionalNullableString(transaction, 'taxSourceCountry', path),
+        taxSourceRegion: optionalNullableString(transaction, 'taxSourceRegion', path),
+        taxTreatment: optionalOneOf(transaction, 'taxTreatment', path, TAX_TREATMENTS, 'UNKNOWN') as TaxTreatment,
+        taxWithheldAmount: optionalNullableNonNegativeNumber(transaction, 'taxWithheldAmount', path),
+        taxWithheldCurrency: optionalNullableString(transaction, 'taxWithheldCurrency', path),
+        taxWithheldCountry: optionalNullableString(transaction, 'taxWithheldCountry', path),
+        taxDocumentRef: optionalNullableString(transaction, 'taxDocumentRef', path),
+        accountId: requireIntegerId(transaction.accountId, `${path}.accountId`),
+        categoryId: transaction.categoryId == null ? null : requireIntegerId(transaction.categoryId, `${path}.categoryId`),
+        transferGroup: optionalNullableString(transaction, 'transferGroup', path),
+        transferDirection: transaction.transferDirection == null
+            ? null
+            : requireOneOf(transaction.transferDirection, `${path}.transferDirection`, TRANSFER_DIRECTIONS) as TransferDirection,
+        transferPeerAccountId: transaction.transferPeerAccountId == null
+            ? null
+            : requireIntegerId(transaction.transferPeerAccountId, `${path}.transferPeerAccountId`),
+    }
+}
+
+function normalizeTaxProfile(value: unknown, index: number): BudgetBackupTaxProfile {
+    const path = `data.taxProfiles[${index}]`
+    const taxProfile = requireRecord(value, path)
+    const year = requireFiniteNumber(taxProfile.year, `${path}.year`)
+
+    if (!Number.isInteger(year) || year < 1900 || year > 2200) {
+        fail(`${path}.year doit être une année fiscale valide.`)
+    }
+
+    return {
+        id: requireIntegerId(taxProfile.id, `${path}.id`),
+        year,
+        residenceCountry: requireNonEmptyString(taxProfile.residenceCountry, `${path}.residenceCountry`).toUpperCase(),
+        residenceRegion: optionalNullableString(taxProfile, 'residenceRegion', path),
+        currency: requireNonEmptyString(taxProfile.currency, `${path}.currency`).toUpperCase(),
+    }
+}
+
+function normalizeSnapshot(parsed: unknown): BudgetBackupSnapshot {
+    const root = requireRecord(parsed, 'backup')
+
+    if (root.kind !== BUDGET_BACKUP_KIND) {
+        fail(INVALID_BACKUP_MESSAGE)
+    }
+
+    const version = parseVersion(root.version)
+    const data = requireRecord(root.data, 'data')
+
+    const snapshot: BudgetBackupSnapshot = {
+        kind: BUDGET_BACKUP_KIND,
+        version,
+        exportedAt: requireExportedAt(root.exportedAt),
+        data: {
+            accounts: requireArray(data.accounts, 'data.accounts').map(normalizeAccount),
+            categories: requireArray(data.categories, 'data.categories').map(normalizeCategory),
+            budgetTargets: requireArray(data.budgetTargets, 'data.budgetTargets').map(normalizeBudgetTarget),
+            recurringTemplates: requireArray(data.recurringTemplates, 'data.recurringTemplates').map(normalizeRecurringTemplate),
+            transactions: requireArray(data.transactions, 'data.transactions').map(normalizeTransaction),
+            taxProfiles: data.taxProfiles == null
+                ? []
+                : requireArray(data.taxProfiles, 'data.taxProfiles').map(normalizeTaxProfile),
+        },
+    }
+
+    assertSnapshotConsistency(snapshot)
+    return snapshot
+}
+
+function assertSnapshotConsistency(snapshot: BudgetBackupSnapshot) {
+    const accounts = snapshot.data.accounts
+    const categories = snapshot.data.categories
+    const budgetTargets = snapshot.data.budgetTargets
+    const recurringTemplates = snapshot.data.recurringTemplates
+    const transactions = snapshot.data.transactions
+    const taxProfiles = snapshot.data.taxProfiles || []
+
+    ensureUniqueIds(accounts, 'data.accounts')
+    ensureUniqueIds(categories, 'data.categories')
+    ensureUniqueIds(budgetTargets, 'data.budgetTargets')
+    ensureUniqueIds(recurringTemplates, 'data.recurringTemplates')
+    ensureUniqueIds(transactions, 'data.transactions')
+    ensureUniqueIds(taxProfiles, 'data.taxProfiles')
+
+    const accountIds = new Set(accounts.map((account) => account.id))
+    const categoryIds = new Set(categories.map((category) => category.id))
+
+    for (const account of accounts) {
+        if (account.openedAt && account.closedAt && new Date(account.closedAt).getTime() < new Date(account.openedAt).getTime()) {
+            fail(`Compte "${account.name}" : la date de fermeture précède la date d'ouverture.`)
+        }
+    }
+
+    for (const budgetTarget of budgetTargets) {
+        if (!categoryIds.has(budgetTarget.categoryId)) {
+            fail(`Budget "${budgetTarget.name}" référence une catégorie absente (${budgetTarget.categoryId}).`)
+        }
+    }
+
+    for (const template of recurringTemplates) {
+        if (!accountIds.has(template.accountId)) {
+            fail(`Récurrence "${template.label}" référence un compte absent (${template.accountId}).`)
+        }
+
+        if (template.categoryId != null && !categoryIds.has(template.categoryId)) {
+            fail(`Récurrence "${template.label}" référence une catégorie absente (${template.categoryId}).`)
+        }
+    }
+
+    const transferGroups = new Map<string, BudgetBackupTransaction[]>()
+
+    for (const transaction of transactions) {
+        if (!accountIds.has(transaction.accountId)) {
+            fail(`Transaction "${transaction.label}" référence un compte absent (${transaction.accountId}).`)
+        }
+
+        if (transaction.categoryId != null && !categoryIds.has(transaction.categoryId)) {
+            fail(`Transaction "${transaction.label}" référence une catégorie absente (${transaction.categoryId}).`)
+        }
+
+        if (transaction.transferPeerAccountId != null && !accountIds.has(transaction.transferPeerAccountId)) {
+            fail(`Transaction "${transaction.label}" référence un compte pair absent (${transaction.transferPeerAccountId}).`)
+        }
+
+        if (transaction.kind === 'TRANSFER' && transaction.categoryId != null) {
+            fail(`Transaction "${transaction.label}" est un transfert mais porte une catégorie (${transaction.categoryId}).`)
+        }
+
+        if (transaction.transferGroup) {
+            const rows = transferGroups.get(transaction.transferGroup) || []
+            rows.push(transaction)
+            transferGroups.set(transaction.transferGroup, rows)
+        }
+    }
+
+    for (const [group, rows] of transferGroups.entries()) {
+        if (rows.length !== 2) {
+            fail(`Le transfert interne ${group} doit contenir exactement deux jambes.`)
+        }
+
+        const outgoing = rows.find((transaction) => transaction.transferDirection === 'OUT')
+        const incoming = rows.find((transaction) => transaction.transferDirection === 'IN')
+
+        if (!outgoing || !incoming) {
+            fail(`Le transfert interne ${group} doit contenir une jambe OUT et une jambe IN.`)
+        }
+
+        if (outgoing.kind !== 'TRANSFER' || incoming.kind !== 'TRANSFER') {
+            fail(`Le transfert interne ${group} contient une transaction qui n'est pas un transfert.`)
+        }
+
+        if (
+            outgoing.accountId === incoming.accountId ||
+            outgoing.transferPeerAccountId !== incoming.accountId ||
+            incoming.transferPeerAccountId !== outgoing.accountId
+        ) {
+            fail(`Le transfert interne ${group} est incohérent.`)
+        }
+    }
+}
 
 export function createBudgetBackupSnapshot(
     accounts: Account[],
@@ -18,8 +535,8 @@ export function createBudgetBackupSnapshot(
     taxProfiles: TaxProfile[] = [],
 ): BudgetBackupSnapshot {
     return {
-        kind: 'budget-backup',
-        version: 4,
+        kind: BUDGET_BACKUP_KIND,
+        version: BUDGET_BACKUP_FORMAT_VERSION,
         exportedAt: new Date().toISOString(),
         data: {
             accounts: accounts.map((account) => ({
@@ -116,22 +633,13 @@ export function serializeBudgetBackup(snapshot: BudgetBackupSnapshot) {
 }
 
 export function parseBudgetBackup(content: string): BudgetBackupSnapshot {
-    const parsed = JSON.parse(content)
+    let parsed: unknown
 
-    if (
-        !parsed ||
-        parsed.kind !== 'budget-backup' ||
-        ![2, 3, 4].includes(parsed.version) ||
-        !parsed.data ||
-        !Array.isArray(parsed.data.accounts) ||
-        !Array.isArray(parsed.data.categories) ||
-        !Array.isArray(parsed.data.budgetTargets) ||
-        !Array.isArray(parsed.data.recurringTemplates) ||
-        !Array.isArray(parsed.data.transactions) ||
-        (parsed.data.taxProfiles != null && !Array.isArray(parsed.data.taxProfiles))
-    ) {
-        throw new Error('Le fichier JSON ne correspond pas à un backup budget valide.')
+    try {
+        parsed = JSON.parse(content)
+    } catch (_error) {
+        fail('Le fichier JSON est invalide ou corrompu.')
     }
 
-    return parsed as BudgetBackupSnapshot
+    return normalizeSnapshot(parsed)
 }


### PR DESCRIPTION
## Résumé

- Ajoute une version de format explicite pour les backups JSON et centralise les versions supportées (`2`, `3`, `4`).
- Remplace le parsing permissif par une validation/normalisation stricte avant restauration : structure, types, dates, IDs, références internes, doublons et transferts internes incohérents.
- Refuse les backups invalides avant la prévisualisation/restauration avec des messages plus exploitables.
- Restaure aussi les profils fiscaux et les métadonnées fiscales des comptes/transactions présentes dans le snapshot.
- Documente les garanties/limites du format JSON dans `docs/json-backup-format.md`.
- Ajoute des tests Vitest couvrant le format courant, l’ancien format, les versions non supportées, les références cassées et les transferts corrompus.

## Tests

- Non exécutés localement ici : l’environnement ne peut pas cloner le repo GitHub directement.
- Couverture ajoutée dans `src/test/utils/jsonBackup.test.ts`.

Closes #11