### PR TITLE
Add desktop E2E smoke test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,11 @@ jobs:
 
       - name: Run tests
         run: npm run test:run
+
+      - name: Install desktop E2E system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
+      - name: Run desktop E2E smoke test
+        run: xvfb-run --auto-servernum npm run test:e2e

--- a/electron/db/resolveDatabasePath.js
+++ b/electron/db/resolveDatabasePath.js
@@ -54,9 +54,23 @@ function shouldSeedPackagedDatabase(dbPath) {
     return fs.statSync(dbPath).size === 0
 }
 
+function resolveExplicitDatabasePath(options = {}) {
+    const explicitPath = options.explicitDatabasePath || process.env.BUDGET_DATABASE_PATH
+    if (!explicitPath) return null
+
+    const dbPath = path.resolve(explicitPath)
+    ensureParentDir(dbPath)
+    return dbPath
+}
+
 function resolveDatabasePathForApp(appApi, options = {}) {
     if (!appApi) {
         throw new Error('An Electron app-like object is required to resolve the database path.')
+    }
+
+    const explicitDatabasePath = resolveExplicitDatabasePath(options)
+    if (explicitDatabasePath) {
+        return explicitDatabasePath
     }
 
     if (!appApi.isPackaged) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "publish": "npm run prepackage:desktop && electron-forge publish",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "npm run prisma:generate && npm run build:vite && node tests/e2e/electron-smoke.cjs",
     "test:coverage": "vitest run --coverage",
     "validate:desktop-assets": "node scripts/validate-desktop-assets.js",
     "build:packaged-db": "node scripts/build-packaged-db.js",

--- a/src/test/resolveDatabasePath.test.mjs
+++ b/src/test/resolveDatabasePath.test.mjs
@@ -35,12 +35,37 @@ function fakeApp({isPackaged, userDataPath, appPath}) {
 }
 
 afterEach(() => {
+    delete process.env.BUDGET_DATABASE_PATH
+
     while (tempDirs.length > 0) {
         fs.rmSync(tempDirs.pop(), {recursive: true, force: true})
     }
 })
 
 describe('resolveDatabasePathForApp', () => {
+    it('uses an explicit database path before development or packaged defaults', () => {
+        const repoRoot = makeTempDir()
+        const explicitRoot = makeTempDir()
+        const explicitDatabasePath = path.join(explicitRoot, 'nested', 'e2e.db')
+        const app = fakeApp({isPackaged: false})
+
+        const dbPath = resolveDatabasePathForApp(app, {repoRoot, explicitDatabasePath})
+
+        expect(dbPath).toBe(explicitDatabasePath)
+        expect(fs.existsSync(path.dirname(dbPath))).toBe(true)
+    })
+
+    it('uses BUDGET_DATABASE_PATH when present', () => {
+        const explicitRoot = makeTempDir()
+        process.env.BUDGET_DATABASE_PATH = path.join(explicitRoot, 'env', 'test.db')
+        const app = fakeApp({isPackaged: false})
+
+        const dbPath = resolveDatabasePathForApp(app)
+
+        expect(dbPath).toBe(process.env.BUDGET_DATABASE_PATH)
+        expect(fs.existsSync(path.dirname(dbPath))).toBe(true)
+    })
+
     it('uses prisma/dev.db inside the repository in development', () => {
         const repoRoot = makeTempDir()
         const app = fakeApp({isPackaged: false})

--- a/tests/e2e/electron-smoke.cjs
+++ b/tests/e2e/electron-smoke.cjs
@@ -1,0 +1,235 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const {spawn, spawnSync} = require('node:child_process')
+
+const repoRoot = path.resolve(__dirname, '..', '..')
+const electronPath = require('electron')
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'budget-e2e-'))
+const testDbPath = path.join(tempRoot, 'data', 'e2e.db')
+const remoteDebuggingPort = Number(process.env.BUDGET_E2E_CDP_PORT || 9333)
+
+function sqliteUrl(filePath) {
+    return `file:${filePath.replace(/\\/g, '/')}`
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+        ...options,
+        env: {
+            ...process.env,
+            ...options.env,
+        },
+    })
+
+    if (result.status !== 0) {
+        throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`)
+    }
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message)
+    }
+}
+
+async function waitFor(fn, {timeoutMs = 30000, intervalMs = 250, message = 'Timed out'} = {}) {
+    const startedAt = Date.now()
+    let lastError = null
+
+    while (Date.now() - startedAt < timeoutMs) {
+        try {
+            const value = await fn()
+            if (value) return value
+        } catch (error) {
+            lastError = error
+        }
+
+        await sleep(intervalMs)
+    }
+
+    if (lastError) {
+        throw new Error(`${message}: ${lastError.message}`)
+    }
+
+    throw new Error(message)
+}
+
+async function getJson(url) {
+    const response = await fetch(url)
+    if (!response.ok) {
+        throw new Error(`GET ${url} failed with ${response.status}`)
+    }
+    return response.json()
+}
+
+class CdpClient {
+    constructor(webSocketUrl) {
+        this.nextId = 1
+        this.pending = new Map()
+        this.socket = new WebSocket(webSocketUrl)
+
+        this.ready = new Promise((resolve, reject) => {
+            this.socket.addEventListener('open', resolve, {once: true})
+            this.socket.addEventListener('error', reject, {once: true})
+        })
+
+        this.socket.addEventListener('message', (event) => {
+            const payload = JSON.parse(event.data)
+            if (!payload.id) return
+
+            const pending = this.pending.get(payload.id)
+            if (!pending) return
+
+            this.pending.delete(payload.id)
+            if (payload.error) {
+                pending.reject(new Error(payload.error.message || JSON.stringify(payload.error)))
+                return
+            }
+
+            pending.resolve(payload.result)
+        })
+    }
+
+    async send(method, params = {}) {
+        await this.ready
+        const id = this.nextId++
+        const payload = {id, method, params}
+
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, {resolve, reject})
+            this.socket.send(JSON.stringify(payload))
+        })
+    }
+
+    async evaluate(expression, {awaitPromise = false} = {}) {
+        const result = await this.send('Runtime.evaluate', {
+            expression,
+            awaitPromise,
+            returnByValue: true,
+        })
+
+        if (result.exceptionDetails) {
+            throw new Error(result.exceptionDetails.text || 'Runtime evaluation failed')
+        }
+
+        return result.result.value
+    }
+
+    close() {
+        this.socket.close()
+    }
+}
+
+async function runSmokeTest() {
+    fs.mkdirSync(path.dirname(testDbPath), {recursive: true})
+
+    run('npx', ['prisma', 'db', 'push', '--skip-generate'], {
+        env: {
+            DATABASE_URL: sqliteUrl(testDbPath),
+        },
+    })
+
+    const electron = spawn(electronPath, [
+        repoRoot,
+        `--remote-debugging-port=${remoteDebuggingPort}`,
+        '--no-sandbox',
+    ], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+            ...process.env,
+            BUDGET_DATABASE_PATH: testDbPath,
+            ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+        },
+    })
+
+    const logs = []
+    electron.stdout.on('data', (chunk) => logs.push(chunk.toString()))
+    electron.stderr.on('data', (chunk) => logs.push(chunk.toString()))
+
+    electron.on('exit', (code, signal) => {
+        if (code !== 0 && signal !== 'SIGTERM') {
+            logs.push(`Electron exited with code ${code} signal ${signal}`)
+        }
+    })
+
+    let cdp = null
+
+    try {
+        const target = await waitFor(async () => {
+            const targets = await getJson(`http://127.0.0.1:${remoteDebuggingPort}/json/list`)
+            return targets.find((entry) => entry.type === 'page' && entry.webSocketDebuggerUrl)
+        }, {message: 'Electron renderer did not expose a CDP page target'})
+
+        cdp = new CdpClient(target.webSocketDebuggerUrl)
+        await cdp.send('Runtime.enable')
+
+        await waitFor(async () => cdp.evaluate('document.readyState === "complete"'), {
+            message: 'Renderer did not finish loading',
+        })
+
+        await waitFor(async () => cdp.evaluate('Boolean(window.versions && window.appShell && window.db)'), {
+            message: 'Preload APIs were not exposed to the renderer',
+        })
+
+        const ping = await cdp.evaluate('window.versions.ping()', {awaitPromise: true})
+        assert(ping === 'pong', 'Expected IPC ping to return pong')
+
+        const version = await cdp.evaluate('window.appShell.getVersion()', {awaitPromise: true})
+        assert(typeof version === 'string' && version.length > 0, 'Expected app version to be readable')
+
+        const accountCount = await cdp.evaluate('window.db.account.list().then((rows) => rows.length)', {awaitPromise: true})
+        assert(accountCount === 0, 'Expected the E2E test database to start empty')
+
+        await waitFor(async () => cdp.evaluate('document.body.innerText.includes("Budget")'), {
+            message: 'Budget shell did not render',
+        })
+
+        const navMarkers = await cdp.evaluate(`Array.from(document.querySelectorAll('nav button')).map((button) => button.innerText.trim().split(/\\s+/)[0])`)
+        for (const marker of ['OV', 'TX', 'AC', 'CA', 'BG', 'RC', 'RP']) {
+            assert(navMarkers.includes(marker), `Expected navigation marker ${marker} to be rendered`)
+        }
+
+        for (const marker of ['TX', 'AC', 'CA', 'BG', 'RC', 'RP', 'OV']) {
+            const clicked = await cdp.evaluate(`(() => {
+                const button = Array.from(document.querySelectorAll('nav button')).find((entry) => entry.innerText.trim().startsWith('${marker}'))
+                if (!button) return false
+                button.click()
+                return true
+            })()`)
+
+            assert(clicked, `Could not click navigation marker ${marker}`)
+
+            await waitFor(async () => cdp.evaluate(`(() => {
+                const active = document.querySelector('nav button.nav-item-active')
+                return Boolean(active && active.innerText.trim().startsWith('${marker}'))
+            })()`), {
+                message: `Navigation did not activate marker ${marker}`,
+            })
+        }
+
+        console.log(`Desktop E2E smoke test passed against app version ${version}`)
+    } catch (error) {
+        console.error('\nElectron output before failure:\n')
+        console.error(logs.join('\n'))
+        throw error
+    } finally {
+        if (cdp) cdp.close()
+        electron.kill('SIGTERM')
+        await sleep(500)
+        fs.rmSync(tempRoot, {recursive: true, force: true})
+    }
+}
+
+runSmokeTest().catch((error) => {
+    console.error(error)
+    process.exit(1)
+})

--- a/tests/e2e/electron-smoke.cjs
+++ b/tests/e2e/electron-smoke.cjs
@@ -138,9 +138,9 @@ async function runSmokeTest() {
     })
 
     const electron = spawn(electronPath, [
-        repoRoot,
         `--remote-debugging-port=${remoteDebuggingPort}`,
         '--no-sandbox',
+        repoRoot,
     ], {
         cwd: repoRoot,
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- Add a dependency-free Electron E2E smoke test using Chrome DevTools Protocol
- Run the smoke test against an isolated temporary SQLite database
- Add `BUDGET_DATABASE_PATH` support so E2E runs never touch `prisma/dev.db`
- Extend CI with `xvfb-run npm run test:e2e`
- Cover explicit database path resolution in unit tests

## What the E2E test verifies

- Electron boots and exposes a renderer CDP target
- preload APIs are available in the renderer
- `window.versions.ping()` reaches the main-process IPC handler
- `window.appShell.getVersion()` returns the desktop app version
- the isolated database starts empty
- the Budget shell renders
- all main navigation entries are visible and clickable

## Validation

I could not execute the test from this environment, so CI should be treated as the source of truth for the first run.

Local commands:

```sh
npm run check
npm run test:e2e
```

On Linux/headless CI:

```sh
xvfb-run --auto-servernum npm run test:e2e
```