### PR TITLE
Collapse overview analytics toolbar outside overview tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -363,7 +363,8 @@ onMounted(async () => {
       <div class="flex min-w-0 flex-1 flex-col">
         <header
             class="sticky top-0 z-20 border-b border-slate-200/70 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
-          <div class="relative mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <div
+              class="relative mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
             <div class="flex min-w-0 items-center gap-3">
               <button
                   class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 dark:border-slate-800 dark:text-slate-400 dark:hover:border-slate-700 dark:hover:text-white lg:hidden"
@@ -402,7 +403,8 @@ onMounted(async () => {
                     :aria-expanded="analyticsPanelOpen"
                     @click="analyticsPanelOpen = !analyticsPanelOpen"
                 >
-                  <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-violet-600 text-xs font-bold text-white shadow-sm shadow-violet-950/30">
+                  <span
+                      class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-violet-600 text-xs font-bold text-white shadow-sm shadow-violet-950/30">
                     OV
                   </span>
                   <span class="hidden min-w-0 flex-col leading-tight sm:flex">
@@ -411,7 +413,8 @@ onMounted(async () => {
                       {{ compactAnalyticsSummary }} · {{ budget.transactions.value.length }} tx
                     </span>
                   </span>
-                  <span class="text-lg transition-transform duration-200" :class="analyticsPanelOpen ? 'rotate-180' : ''">
+                  <span class="text-lg transition-transform duration-200"
+                        :class="analyticsPanelOpen ? 'rotate-180' : ''">
                     ⌄
                   </span>
                 </button>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed, onMounted, ref} from 'vue'
+import {computed, onMounted, ref, watch} from 'vue'
 import {useI18n} from 'vue-i18n'
 import AccountsSection from './components/AccountsSection.vue'
 import AnalyticsToolbar from './components/AnalyticsToolbar.vue'
@@ -21,11 +21,13 @@ import {useJsonBackup} from './composables/useJsonBackup'
 import {useRecurringTemplates} from './composables/useRecurringTemplates'
 import {useReports} from './composables/useReports'
 import {useSettings} from './composables/useSettings'
+import {formatMoney} from './utils/budgetFormat'
 import type {CreateTabKey, ReportPreset, SectionKey, TaxProfile} from './types/budget'
 
 const notice = ref<{ type: 'success' | 'error'; text: string } | null>(null)
 const appVersion = ref('')
 const taxProfiles = ref<TaxProfile[]>([])
+const analyticsPanelOpen = ref(false)
 
 function showNotice(type: 'success' | 'error', text: string) {
   notice.value = {type, text}
@@ -149,6 +151,9 @@ const sectionMeta = computed<Record<SectionKey, { title: string; description: st
 
 const viewTitle = computed(() => sectionMeta.value[budget.activeSection.value].title)
 const viewDescription = computed(() => sectionMeta.value[budget.activeSection.value].description)
+const showExpandedAnalytics = computed(() => budget.activeSection.value === 'overview')
+const showCollapsedAnalytics = computed(() => budget.activeSection.value !== 'overview')
+const compactAnalyticsSummary = computed(() => formatMoney(budget.netFlow.value, budget.summaryCurrency.value))
 
 const csvPreviewLines = computed(() => {
   const summary = csv.importPreviewSummary.value
@@ -178,6 +183,10 @@ const restorePreviewLines = computed(() => {
 
 function setCreateTab(tab: CreateTabKey) {
   budget.createTab.value = tab
+}
+
+function closeCompactAnalyticsAfterAction() {
+  analyticsPanelOpen.value = false
 }
 
 function handleMenuCommand(rawCommand: unknown) {
@@ -247,6 +256,10 @@ function handleMenuCommand(rawCommand: unknown) {
       break
   }
 }
+
+watch(() => budget.activeSection.value, () => {
+  analyticsPanelOpen.value = false
+})
 
 onMounted(async () => {
   settings.initSettings()
@@ -350,7 +363,7 @@ onMounted(async () => {
       <div class="flex min-w-0 flex-1 flex-col">
         <header
             class="sticky top-0 z-20 border-b border-slate-200/70 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
-          <div class="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <div class="relative mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
             <div class="flex min-w-0 items-center gap-3">
               <button
                   class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-900 dark:border-slate-800 dark:text-slate-400 dark:hover:border-slate-700 dark:hover:text-white lg:hidden"
@@ -375,6 +388,26 @@ onMounted(async () => {
             </div>
 
             <div class="flex shrink-0 items-center gap-2">
+              <button
+                  v-if="showCollapsedAnalytics"
+                  class="group inline-flex items-center gap-3 rounded-2xl border border-violet-200 bg-violet-50 px-3 py-2 text-left text-sm font-semibold text-violet-700 shadow-sm transition hover:border-violet-300 hover:bg-violet-100 dark:border-violet-900/60 dark:bg-violet-950/45 dark:text-violet-200 dark:hover:border-violet-800 dark:hover:bg-violet-950/70"
+                  :aria-expanded="analyticsPanelOpen"
+                  @click="analyticsPanelOpen = !analyticsPanelOpen"
+              >
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-violet-600 text-xs font-bold text-white shadow-sm shadow-violet-950/30">
+                  OV
+                </span>
+                <span class="hidden min-w-0 flex-col leading-tight sm:flex">
+                  <span>{{ t('nav.overview') }}</span>
+                  <span class="text-xs font-medium text-violet-500 dark:text-violet-300/80">
+                    {{ compactAnalyticsSummary }} · {{ budget.transactions.value.length }} tx
+                  </span>
+                </span>
+                <span class="text-lg transition-transform duration-200" :class="analyticsPanelOpen ? 'rotate-180' : ''">
+                  ⌄
+                </span>
+              </button>
+
               <button class="ghost-btn" @click="settings.openSettings">
                 {{ t('common.settings') }}
               </button>
@@ -385,6 +418,37 @@ onMounted(async () => {
                 {{ t('common.add') }}
               </button>
             </div>
+
+            <Transition
+                enter-active-class="transition duration-200 ease-out"
+                enter-from-class="translate-y-2 opacity-0 scale-95"
+                enter-to-class="translate-y-0 opacity-100 scale-100"
+                leave-active-class="transition duration-150 ease-in"
+                leave-from-class="translate-y-0 opacity-100 scale-100"
+                leave-to-class="translate-y-2 opacity-0 scale-95"
+            >
+              <div
+                  v-if="showCollapsedAnalytics && analyticsPanelOpen"
+                  class="absolute right-4 top-[calc(100%+0.75rem)] z-50 w-[min(44rem,calc(100vw-2rem))] origin-top-right sm:right-6 lg:right-8"
+              >
+                <AnalyticsToolbar
+                    compact
+                    :loading="budget.loading.value"
+                    :summary-currency="budget.summaryCurrency.value"
+                    :net-flow="budget.netFlow.value"
+                    :total-income="budget.totalIncome.value"
+                    :total-expense="budget.totalExpense.value"
+                    :transaction-count="budget.transactions.value.length"
+                    :account-count="budget.accounts.value.length"
+                    :category-count="budget.categories.value.length"
+                    :current-csv-entity="csv.currentCsvEntity.value"
+                    @refresh="refreshEverything"
+                    @create-transaction="budget.openCreatePanel('transaction'); closeCompactAnalyticsAfterAction()"
+                    @create-account="budget.openCreatePanel('account'); closeCompactAnalyticsAfterAction()"
+                    @create-category="budget.openCreatePanel('category'); closeCompactAnalyticsAfterAction()"
+                />
+              </div>
+            </Transition>
           </div>
         </header>
 
@@ -396,6 +460,7 @@ onMounted(async () => {
           </div>
 
           <AnalyticsToolbar
+              v-if="showExpandedAnalytics"
               :loading="budget.loading.value"
               :summary-currency="budget.summaryCurrency.value"
               :net-flow="budget.netFlow.value"
@@ -535,6 +600,13 @@ onMounted(async () => {
         </main>
       </div>
     </div>
+
+    <button
+        v-if="analyticsPanelOpen"
+        class="fixed inset-0 z-40 cursor-default bg-transparent"
+        aria-label="Close overview summary"
+        @click="analyticsPanelOpen = false"
+    />
 
     <EntityDrawer
         :open="budget.createPanelOpen.value"

--- a/src/App.vue
+++ b/src/App.vue
@@ -388,25 +388,34 @@ onMounted(async () => {
             </div>
 
             <div class="flex shrink-0 items-center gap-2">
-              <button
-                  v-if="showCollapsedAnalytics"
-                  class="group inline-flex items-center gap-3 rounded-2xl border border-violet-200 bg-violet-50 px-3 py-2 text-left text-sm font-semibold text-violet-700 shadow-sm transition hover:border-violet-300 hover:bg-violet-100 dark:border-violet-900/60 dark:bg-violet-950/45 dark:text-violet-200 dark:hover:border-violet-800 dark:hover:bg-violet-950/70"
-                  :aria-expanded="analyticsPanelOpen"
-                  @click="analyticsPanelOpen = !analyticsPanelOpen"
+              <Transition
+                  enter-active-class="transition delay-150 duration-300 ease-out"
+                  enter-from-class="translate-x-4 scale-90 opacity-0 blur-[1px]"
+                  enter-to-class="translate-x-0 scale-100 opacity-100 blur-0"
+                  leave-active-class="transition duration-150 ease-in"
+                  leave-from-class="translate-x-0 scale-100 opacity-100"
+                  leave-to-class="translate-x-2 scale-95 opacity-0"
               >
-                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-violet-600 text-xs font-bold text-white shadow-sm shadow-violet-950/30">
-                  OV
-                </span>
-                <span class="hidden min-w-0 flex-col leading-tight sm:flex">
-                  <span>{{ t('nav.overview') }}</span>
-                  <span class="text-xs font-medium text-violet-500 dark:text-violet-300/80">
-                    {{ compactAnalyticsSummary }} · {{ budget.transactions.value.length }} tx
+                <button
+                    v-if="showCollapsedAnalytics"
+                    class="group inline-flex transform-gpu items-center gap-3 rounded-2xl border border-violet-200 bg-violet-50 px-3 py-2 text-left text-sm font-semibold text-violet-700 shadow-sm transition hover:border-violet-300 hover:bg-violet-100 dark:border-violet-900/60 dark:bg-violet-950/45 dark:text-violet-200 dark:hover:border-violet-800 dark:hover:bg-violet-950/70"
+                    :aria-expanded="analyticsPanelOpen"
+                    @click="analyticsPanelOpen = !analyticsPanelOpen"
+                >
+                  <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-violet-600 text-xs font-bold text-white shadow-sm shadow-violet-950/30">
+                    OV
                   </span>
-                </span>
-                <span class="text-lg transition-transform duration-200" :class="analyticsPanelOpen ? 'rotate-180' : ''">
-                  ⌄
-                </span>
-              </button>
+                  <span class="hidden min-w-0 flex-col leading-tight sm:flex">
+                    <span>{{ t('nav.overview') }}</span>
+                    <span class="text-xs font-medium text-violet-500 dark:text-violet-300/80">
+                      {{ compactAnalyticsSummary }} · {{ budget.transactions.value.length }} tx
+                    </span>
+                  </span>
+                  <span class="text-lg transition-transform duration-200" :class="analyticsPanelOpen ? 'rotate-180' : ''">
+                    ⌄
+                  </span>
+                </button>
+              </Transition>
 
               <button class="ghost-btn" @click="settings.openSettings">
                 {{ t('common.settings') }}
@@ -459,22 +468,32 @@ onMounted(async () => {
             </div>
           </div>
 
-          <AnalyticsToolbar
-              v-if="showExpandedAnalytics"
-              :loading="budget.loading.value"
-              :summary-currency="budget.summaryCurrency.value"
-              :net-flow="budget.netFlow.value"
-              :total-income="budget.totalIncome.value"
-              :total-expense="budget.totalExpense.value"
-              :transaction-count="budget.transactions.value.length"
-              :account-count="budget.accounts.value.length"
-              :category-count="budget.categories.value.length"
-              :current-csv-entity="csv.currentCsvEntity.value"
-              @refresh="refreshEverything"
-              @create-transaction="budget.openCreatePanel('transaction')"
-              @create-account="budget.openCreatePanel('account')"
-              @create-category="budget.openCreatePanel('category')"
-          />
+          <Transition
+              enter-active-class="transition duration-300 ease-out"
+              enter-from-class="-translate-y-4 scale-[0.98] opacity-0"
+              enter-to-class="translate-y-0 scale-100 opacity-100"
+              leave-active-class="transition duration-300 ease-in"
+              leave-from-class="translate-x-0 translate-y-0 scale-100 opacity-100 blur-0"
+              leave-to-class="pointer-events-none -translate-y-16 translate-x-[18%] scale-[0.72] opacity-0 blur-[1px]"
+          >
+            <div v-if="showExpandedAnalytics" class="origin-top-right transform-gpu">
+              <AnalyticsToolbar
+                  :loading="budget.loading.value"
+                  :summary-currency="budget.summaryCurrency.value"
+                  :net-flow="budget.netFlow.value"
+                  :total-income="budget.totalIncome.value"
+                  :total-expense="budget.totalExpense.value"
+                  :transaction-count="budget.transactions.value.length"
+                  :account-count="budget.accounts.value.length"
+                  :category-count="budget.categories.value.length"
+                  :current-csv-entity="csv.currentCsvEntity.value"
+                  @refresh="refreshEverything"
+                  @create-transaction="budget.openCreatePanel('transaction')"
+                  @create-account="budget.openCreatePanel('account')"
+                  @create-category="budget.openCreatePanel('category')"
+              />
+            </div>
+          </Transition>
 
           <OverviewSection
               v-if="budget.activeSection.value === 'overview'"

--- a/src/App.vue
+++ b/src/App.vue
@@ -603,7 +603,7 @@ onMounted(async () => {
 
     <button
         v-if="analyticsPanelOpen"
-        class="fixed inset-0 z-40 cursor-default bg-transparent"
+        class="fixed inset-0 z-10 cursor-default bg-transparent"
         aria-label="Close overview summary"
         @click="analyticsPanelOpen = false"
     />

--- a/src/components/AnalyticsToolbar.vue
+++ b/src/components/AnalyticsToolbar.vue
@@ -3,7 +3,7 @@ import {useI18n} from 'vue-i18n'
 import type {EntityType} from '../types/budget'
 import {entityCollectionLabel, formatMoney} from '../utils/budgetFormat'
 
-defineProps<{
+withDefaults(defineProps<{
   loading: boolean
   summaryCurrency: string
   netFlow: number
@@ -13,7 +13,10 @@ defineProps<{
   accountCount: number
   categoryCount: number
   currentCsvEntity: EntityType
-}>()
+  compact?: boolean
+}>(), {
+  compact: false,
+})
 
 const emit = defineEmits<{
   (e: 'refresh'): void
@@ -26,16 +29,28 @@ const {t} = useI18n()
 </script>
 
 <template>
-  <section class="panel mb-6 overflow-hidden p-6">
-    <div class="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
-      <div class="max-w-3xl">
+  <section
+      class="panel overflow-hidden transition-all duration-300 ease-out"
+      :class="compact ? 'p-4 shadow-2xl shadow-slate-950/20 dark:bg-slate-900/95' : 'mb-6 p-6'"
+  >
+    <div
+        class="flex flex-col"
+        :class="compact ? 'gap-4' : 'gap-6 xl:flex-row xl:items-end xl:justify-between'"
+    >
+      <div :class="compact ? 'max-w-none' : 'max-w-3xl'">
         <p class="soft-kicker">
           {{ t('settings.title') }} + i18n
         </p>
-        <h2 class="mt-2 text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+        <h2
+            class="mt-2 font-bold tracking-tight text-slate-900 dark:text-white"
+            :class="compact ? 'text-xl' : 'text-3xl'"
+        >
           {{ t('toolbar.title') }}
         </h2>
-        <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-400">
+        <p
+            class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-400"
+            :class="compact ? 'line-clamp-2' : ''"
+        >
           {{ t('toolbar.description') }}
           <span class="font-semibold text-slate-800 dark:text-slate-100">
             {{ entityCollectionLabel(currentCsvEntity) }}
@@ -50,10 +65,13 @@ const {t} = useI18n()
       </div>
     </div>
 
-    <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-      <div class="stat-card">
+    <div
+        class="grid"
+        :class="compact ? 'mt-4 gap-3 sm:grid-cols-2' : 'mt-6 gap-4 md:grid-cols-2 xl:grid-cols-4'"
+    >
+      <div class="stat-card" :class="compact ? '!rounded-2xl !p-4' : ''">
         <p class="stat-label">{{ t('analytics.netFlow') }}</p>
-        <p class="stat-value">
+        <p class="stat-value" :class="compact ? '!text-2xl' : ''">
           {{ formatMoney(netFlow, summaryCurrency) }}
         </p>
         <p class="stat-hint">
@@ -61,9 +79,9 @@ const {t} = useI18n()
         </p>
       </div>
 
-      <div class="stat-card">
+      <div class="stat-card" :class="compact ? '!rounded-2xl !p-4' : ''">
         <p class="stat-label">{{ t('analytics.income') }}</p>
-        <p class="stat-value">
+        <p class="stat-value" :class="compact ? '!text-2xl' : ''">
           {{ formatMoney(totalIncome, summaryCurrency) }}
         </p>
         <p class="stat-hint">
@@ -71,9 +89,9 @@ const {t} = useI18n()
         </p>
       </div>
 
-      <div class="stat-card">
+      <div class="stat-card" :class="compact ? '!rounded-2xl !p-4' : ''">
         <p class="stat-label">{{ t('analytics.expense') }}</p>
-        <p class="stat-value">
+        <p class="stat-value" :class="compact ? '!text-2xl' : ''">
           {{ formatMoney(totalExpense, summaryCurrency) }}
         </p>
         <p class="stat-hint">
@@ -81,9 +99,9 @@ const {t} = useI18n()
         </p>
       </div>
 
-      <div class="stat-card">
+      <div class="stat-card" :class="compact ? '!rounded-2xl !p-4' : ''">
         <p class="stat-label">{{ t('analytics.volumes') }}</p>
-        <p class="stat-value text-xl">
+        <p class="stat-value text-xl" :class="compact ? '!text-lg' : ''">
           {{ transactionCount }} tx · {{ accountCount }} cpt · {{ categoryCount }} cat
         </p>
         <p class="stat-hint">
@@ -92,14 +110,17 @@ const {t} = useI18n()
       </div>
     </div>
 
-    <div class="mt-6 flex flex-wrap items-center gap-2">
-      <button class="quick-panel-action" @click="emit('create-transaction')">
+    <div
+        class="grid items-center"
+        :class="compact ? 'mt-4 gap-2 sm:grid-cols-3' : 'mt-6 gap-2 sm:grid-cols-3'"
+    >
+      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-transaction')">
         {{ t('forms.titles.createTransaction') }}
       </button>
-      <button class="quick-panel-action" @click="emit('create-account')">
+      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-account')">
         {{ t('forms.titles.createAccount') }}
       </button>
-      <button class="quick-panel-action" @click="emit('create-category')">
+      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-category')">
         {{ t('forms.titles.createCategory') }}
       </button>
     </div>

--- a/src/components/AnalyticsToolbar.vue
+++ b/src/components/AnalyticsToolbar.vue
@@ -39,7 +39,7 @@ const {t} = useI18n()
     >
       <div :class="compact ? 'max-w-none' : 'max-w-3xl'">
         <p class="soft-kicker">
-          {{ t('settings.title') }} + i18n
+          {{ t('settings.title') }}
         </p>
         <h2
             class="mt-2 font-bold tracking-tight text-slate-900 dark:text-white"
@@ -114,13 +114,15 @@ const {t} = useI18n()
         class="grid items-center"
         :class="compact ? 'mt-4 gap-2 sm:grid-cols-3' : 'mt-6 gap-2 sm:grid-cols-3'"
     >
-      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-transaction')">
+      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''"
+              @click="emit('create-transaction')">
         {{ t('forms.titles.createTransaction') }}
       </button>
       <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-account')">
         {{ t('forms.titles.createAccount') }}
       </button>
-      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''" @click="emit('create-category')">
+      <button class="quick-panel-action" :class="compact ? '!rounded-2xl !py-2.5' : ''"
+              @click="emit('create-category')">
         {{ t('forms.titles.createCategory') }}
       </button>
     </div>


### PR DESCRIPTION
## Summary

- Keep the analytics / quick-actions block expanded only on the `overview` section
- Add a compact `Overview` / quick-stats button in the top-right header area on every other section
- Open the same analytics toolbar as a compact popover with a smooth transition
- Reuse `AnalyticsToolbar` via a `compact` mode instead of duplicating the UI
- Close the compact popover when changing sections or after launching a quick-create action

## UX behavior

- `Overview`: full block stays in the page content, unchanged in purpose
- Other tabs: content is cleaner; the block is accessible from the header button
- The header button shows net flow and transaction count as a quick signal

## Validation

I could not run the app from this environment, so CI/local checks should be treated as the source of truth.

Suggested local checks:

```sh
npm run typecheck
npm run test:run
npm run build:vite
```