### PR TITLE
Fix packaged database build on Windows CI

### DIFF
--- a/scripts/build-packaged-db.js
+++ b/scripts/build-packaged-db.js
@@ -6,19 +6,25 @@ const repoRoot = path.resolve(__dirname, '..')
 const schemaPath = path.join(repoRoot, 'prisma', 'schema.prisma')
 const databaseDir = path.join(repoRoot, 'assets', 'database')
 const databasePath = path.join(databaseDir, 'app.db')
+const prismaBin = path.join(
+    repoRoot,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'prisma.cmd' : 'prisma',
+)
 
 function toSqliteUrl(filePath) {
     return `file:${filePath.replace(/\\/g, '/')}`
 }
 
 function runPrismaDbPush() {
-    const prismaBin = process.platform === 'win32' ? 'npx.cmd' : 'npx'
     return spawnSync(
         prismaBin,
-        ['prisma', 'db', 'push', '--skip-generate', '--schema', schemaPath],
+        ['db', 'push', '--skip-generate', '--schema', schemaPath],
         {
             cwd: repoRoot,
             stdio: 'inherit',
+            shell: process.platform === 'win32',
             env: {
                 ...process.env,
                 DATABASE_URL: toSqliteUrl(databasePath),
@@ -30,8 +36,18 @@ function runPrismaDbPush() {
 fs.mkdirSync(databaseDir, {recursive: true})
 fs.rmSync(databasePath, {force: true})
 
+console.log(`Building packaged database template at ${databasePath}`)
+console.log(`Using Prisma binary at ${prismaBin}`)
+
 const result = runPrismaDbPush()
+if (result.error) {
+    console.error('Failed to start Prisma db push for packaged database template.')
+    console.error(result.error)
+    process.exit(1)
+}
+
 if (result.status !== 0) {
+    console.error(`Prisma db push failed with exit code ${result.status}.`)
     process.exit(result.status || 1)
 }
 


### PR DESCRIPTION
## Summary

- Use the local Prisma CLI binary from `node_modules/.bin` instead of `npx` for packaged DB generation
- Use `prisma.cmd` on Windows CI
- Enable `shell` only on Windows for `.cmd` execution
- Log the packaged DB target path and Prisma binary path
- Print `spawnSync` startup errors explicitly instead of failing with a silent exit code

## Context

The Windows release job currently passes Prisma generate, typecheck, and all Vitest tests, then fails at:

```sh
node scripts/build-packaged-db.js
```

with only `Process completed with exit code 1` in the GitHub Actions log. This patch makes the command more robust on Windows and improves diagnostics if Prisma still fails.

## Validation

CI should be the source of truth for the Windows runner.

Local check:

```sh
npm run build:packaged-db
npm run make:artifacts
```