### PR TITLE
Add missing common import/export locale labels

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -8,6 +8,26 @@ export type SupportedLocale = 'fr' | 'en'
 
 const LOCALE_STORAGE_KEY = 'budget-locale'
 
+const frMessages = {
+    ...fr,
+    common: {
+        ...fr.common,
+        export: 'Exporter',
+        import: 'Importer',
+    },
+    tax: taxFr,
+}
+
+const enMessages = {
+    ...en,
+    common: {
+        ...en.common,
+        export: 'Export',
+        import: 'Import',
+    },
+    tax: taxEn,
+}
+
 export function normalizeLocale(value?: string | null): SupportedLocale {
     const normalized = (value || '').toLowerCase()
     return normalized.startsWith('fr') ? 'fr' : 'en'
@@ -37,14 +57,8 @@ export const i18n = createI18n({
     locale: resolveInitialLocale(),
     fallbackLocale: 'en',
     messages: {
-        fr: {
-            ...fr,
-            tax: taxFr,
-        },
-        en: {
-            ...en,
-            tax: taxEn,
-        },
+        fr: frMessages,
+        en: enMessages,
     },
 })
 


### PR DESCRIPTION
## Summary

- Add missing `common.import` and `common.export` labels to the composed i18n messages
- Keep French and English locales aligned
- Remove Vue I18n warnings seen during CSV/JSON import-export tests

## Context

The test suite passes, but Vitest logs warnings like:

```text
[intlify] Not found 'common.export' key in 'en' locale messages.
[intlify] Not found 'common.import' key in 'en' locale messages.
```

Those keys are used by CSV import/export dialog titles.

## Validation

```sh
npm run test:run
npm run build:vite
```