### PR TITLE
Add shared portfolio analytics contracts

### DIFF
--- a/docs/portfolio-analytics-contracts.md
+++ b/docs/portfolio-analytics-contracts.md
@@ -1,0 +1,60 @@
+# Portfolio analytics contracts
+
+Cette note fixe les conventions de calcul utilisées par les contrats partagés de portefeuille. Le module concerné est `src/types/portfolio.ts`; il doit rester utilisable côté Electron main, services métier et renderer Vue sans dépendance à Prisma, Electron, Vue ou un provider externe.
+
+## Périmètre MVP
+
+Le MVP expose des formes stables pour :
+
+- les actifs (`PortfolioAsset`) ;
+- les positions (`PortfolioPosition`) ;
+- les mouvements (`PortfolioMovement`) ;
+- les valorisations (`PortfolioValuation`) ;
+- les gains/pertes (`PortfolioGainLoss`) ;
+- les allocations (`PortfolioAllocation`) ;
+- les revenus (`PortfolioIncome`) ;
+- les frais (`PortfolioFee`) ;
+- les snapshots de portefeuille (`PortfolioSnapshot`).
+
+Ces contrats décrivent les données nécessaires au dashboard. Ils ne lancent aucun calcul de performance avancé, aucun appel market data et aucune opération de trading.
+
+## Statuts de valorisation
+
+Les statuts sont volontairement explicites et minuscules pour l’UI :
+
+- `market` : valeur calculée avec un prix de marché exploitable ;
+- `manual` : valeur saisie ou importée manuellement ;
+- `stale` : valeur de marché ancienne mais encore affichable ;
+- `missing` : aucune valeur exploitable ;
+- `error` : erreur pendant la valorisation ou donnée incohérente.
+
+L’UI doit afficher les positions `stale`, `missing` et `error` sans casser le total global. Une position sans valeur de marché peut contribuer à `0` au total, mais doit garder un avertissement lisible dans le snapshot.
+
+## Regroupements supportés
+
+Les allocations peuvent être regroupées par :
+
+- actif ;
+- compte ;
+- classe d’actifs ;
+- secteur ;
+- géographie ;
+- devise.
+
+Les clés non renseignées doivent être rangées dans `unclassified` côté helper, puis traduites proprement dans l’UI.
+
+## Conventions de calcul
+
+- Les devises sont normalisées en ISO-like 3 lettres majuscules (`CAD`, `USD`, `EUR`). Une devise invalide retombe sur `CAD` par défaut ou sur le fallback fourni.
+- Les montants monétaires sont arrondis à 2 décimales par défaut. Les helpers acceptent une précision explicite quand un calcul intermédiaire en a besoin.
+- Les pourcentages d’allocation utilisent uniquement les valeurs de marché positives dans le dénominateur implicite. Une valeur négative garde sa valeur affichée, mais contribue à `0 %` dans l’allocation MVP.
+- Les gains/pertes valent `marketValue - bookValue`. Le pourcentage est `null` quand le coût de base vaut `0`, afin d’éviter un faux infini.
+- L’agrégation par clé est pure, déterministe et indépendante de la base de données.
+
+## Hors périmètre
+
+- calcul annualisé, TWR, MWR ou IRR ;
+- fiscalité avancée ;
+- conversion FX historique ;
+- provider market data réel ;
+- rendu UI complet.

--- a/src/test/types/portfolio.test.ts
+++ b/src/test/types/portfolio.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, it} from 'vitest'
+import {
+    PORTFOLIO_GROUPING_KEYS,
+    PORTFOLIO_VALUATION_STATUSES,
+    aggregatePortfolioByKey,
+    calculatePortfolioAllocationPercentages,
+    calculatePortfolioGainLoss,
+    isPortfolioGroupingKey,
+    isPortfolioValuationStatus,
+    normalizePortfolioCurrency,
+    roundPortfolioMoney,
+    type PortfolioAsset,
+    type PortfolioFee,
+    type PortfolioIncome,
+    type PortfolioMovement,
+    type PortfolioPosition,
+    type PortfolioSnapshot,
+    type PortfolioValuation,
+} from '../../types/portfolio'
+
+describe('portfolio analytics shared contracts', () => {
+    it('exposes explicit MVP valuation statuses and grouping keys', () => {
+        expect(PORTFOLIO_VALUATION_STATUSES).toEqual(['market', 'manual', 'stale', 'missing', 'error'])
+        expect(PORTFOLIO_GROUPING_KEYS).toEqual([
+            'asset',
+            'account',
+            'assetClass',
+            'sector',
+            'geography',
+            'currency',
+        ])
+        expect(isPortfolioValuationStatus('market')).toBe(true)
+        expect(isPortfolioValuationStatus('FRESH')).toBe(false)
+        expect(isPortfolioGroupingKey('sector')).toBe(true)
+        expect(isPortfolioGroupingKey('broker')).toBe(false)
+    })
+
+    it('represents dashboard MVP entities without Prisma or Vue dependencies', () => {
+        const asset: PortfolioAsset = {
+            id: 1,
+            symbol: 'XEQT',
+            name: 'iShares Core Equity ETF Portfolio',
+            assetClass: 'etf',
+            sector: 'Diversified',
+            geography: 'Global',
+            currency: 'CAD',
+            marketInstrumentId: 10,
+            isActive: true,
+            note: null,
+        }
+        const totalGainLoss = calculatePortfolioGainLoss(1250, 1000, 'CAD')
+        const position: PortfolioPosition = {
+            id: 100,
+            accountId: 20,
+            accountName: 'Brokerage',
+            assetId: asset.id,
+            asset,
+            quantity: 25,
+            averageCost: 40,
+            bookValue: 1000,
+            marketValue: 1250,
+            currency: 'CAD',
+            valuationStatus: 'market',
+            valuedAt: '2026-04-30T12:00:00.000Z',
+            allocationPercent: 100,
+            unrealizedGainLoss: totalGainLoss,
+        }
+        const movement: PortfolioMovement = {
+            id: 200,
+            accountId: position.accountId,
+            assetId: asset.id,
+            type: 'buy',
+            quantity: 25,
+            unitPrice: 40,
+            grossAmount: 1000,
+            feeAmount: 5,
+            taxAmount: 0,
+            netAmount: 1005,
+            currency: 'CAD',
+            tradeDate: '2026-04-01',
+            settledAt: '2026-04-03',
+            note: null,
+        }
+        const valuation: PortfolioValuation = {
+            assetId: asset.id,
+            accountId: position.accountId,
+            quantity: position.quantity,
+            unitPrice: 50,
+            marketValue: position.marketValue,
+            bookValue: position.bookValue,
+            currency: 'CAD',
+            status: 'market',
+            valuedAt: position.valuedAt,
+            source: 'market_data',
+            warnings: [],
+        }
+        const income: PortfolioIncome = {
+            id: 300,
+            accountId: position.accountId,
+            assetId: asset.id,
+            type: 'dividend',
+            amount: 12.5,
+            currency: 'CAD',
+            paidAt: '2026-04-15',
+            withholdingTaxAmount: 0,
+            note: null,
+        }
+        const fee: PortfolioFee = {
+            id: 400,
+            accountId: position.accountId,
+            assetId: asset.id,
+            type: 'brokerage',
+            amount: 5,
+            currency: 'CAD',
+            chargedAt: movement.tradeDate,
+            note: null,
+        }
+        const snapshot: PortfolioSnapshot = {
+            id: 500,
+            baseCurrency: 'CAD',
+            capturedAt: '2026-04-30T12:01:00.000Z',
+            totalMarketValue: 1250,
+            totalBookValue: 1000,
+            totalGainLoss,
+            positions: [position],
+            allocations: [{
+                groupBy: 'assetClass',
+                key: asset.assetClass,
+                label: 'ETF',
+                marketValue: position.marketValue || 0,
+                currency: 'CAD',
+                allocationPercent: 100,
+                positionsCount: 1,
+            }],
+            income: [income],
+            fees: [fee],
+            valuationStatus: valuation.status,
+            warnings: [],
+        }
+
+        expect(snapshot.positions[0].asset?.symbol).toBe('XEQT')
+        expect(snapshot.totalGainLoss).toEqual({absolute: 250, percent: 25, currency: 'CAD', realized: false})
+        expect(snapshot.allocations[0].groupBy).toBe('assetClass')
+    })
+
+    it('normalizes currencies, rounds money and computes allocation percentages', () => {
+        expect(normalizePortfolioCurrency(' cad ')).toBe('CAD')
+        expect(normalizePortfolioCurrency('too-long', 'usd')).toBe('USD')
+        expect(roundPortfolioMoney(10.005)).toBe(10.01)
+        expect(roundPortfolioMoney(Number.NaN)).toBe(0)
+
+        expect(calculatePortfolioAllocationPercentages([
+            {key: 'equity', label: 'Equity', marketValue: 750, currency: 'cad', positionsCount: 2},
+            {key: 'cash', label: 'Cash', marketValue: 250, currency: 'CAD', positionsCount: 1},
+            {key: 'negative', marketValue: -100, currency: 'CAD'},
+        ])).toEqual([
+            {key: 'equity', label: 'Equity', marketValue: 750, currency: 'CAD', positionsCount: 2, allocationPercent: 75},
+            {key: 'cash', label: 'Cash', marketValue: 250, currency: 'CAD', positionsCount: 1, allocationPercent: 25},
+            {key: 'negative', label: 'negative', marketValue: -100, currency: 'CAD', positionsCount: 0, allocationPercent: 0},
+        ])
+    })
+
+    it('aggregates positions by a provided key without touching storage', () => {
+        const positions = [
+            {sector: 'Technology', marketValue: 400},
+            {sector: 'Financials', marketValue: 250},
+            {sector: 'Technology', marketValue: 100},
+            {sector: null, marketValue: 50},
+        ]
+        const grouped = aggregatePortfolioByKey(
+            positions,
+            (position) => position.sector,
+            (position) => position.marketValue,
+        )
+
+        expect(grouped.map(({key, count, total}) => ({key, count, total}))).toEqual([
+            {key: 'Technology', count: 2, total: 500},
+            {key: 'Financials', count: 1, total: 250},
+            {key: 'unclassified', count: 1, total: 50},
+        ])
+    })
+})

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -1,0 +1,351 @@
+/**
+ * Shared renderer/main contracts for portfolio analytics.
+ *
+ * Keep this module pure: no Prisma models, no Electron APIs, no provider payloads
+ * and no Vue dependencies. Backend services can map database rows into these
+ * contracts, then the renderer can consume the same shapes for the MVP dashboard.
+ */
+export type PortfolioId = number
+export type PortfolioDateString = string
+export type PortfolioDateTimeString = string
+export type PortfolioCurrencyCode = string
+export type PortfolioAccountId = PortfolioId
+export type PortfolioAssetId = PortfolioId
+
+export type PortfolioAssetClass =
+    | 'cash'
+    | 'equity'
+    | 'etf'
+    | 'fund'
+    | 'bond'
+    | 'crypto'
+    | 'real_estate'
+    | 'commodity'
+    | 'forex'
+    | 'other'
+
+export type PortfolioMovementType =
+    | 'buy'
+    | 'sell'
+    | 'deposit'
+    | 'withdrawal'
+    | 'dividend'
+    | 'interest'
+    | 'fee'
+    | 'tax'
+    | 'transfer_in'
+    | 'transfer_out'
+    | 'split'
+    | 'fx_adjustment'
+    | 'manual_adjustment'
+
+export type PortfolioValuationStatus = 'market' | 'manual' | 'stale' | 'missing' | 'error'
+export type PortfolioGroupingKey = 'asset' | 'account' | 'assetClass' | 'sector' | 'geography' | 'currency'
+export type PortfolioIncomeType = 'dividend' | 'interest' | 'distribution' | 'staking' | 'rent' | 'other'
+export type PortfolioFeeType = 'brokerage' | 'management' | 'custody' | 'fx' | 'tax' | 'other'
+
+export const PORTFOLIO_ASSET_CLASSES = [
+    'cash',
+    'equity',
+    'etf',
+    'fund',
+    'bond',
+    'crypto',
+    'real_estate',
+    'commodity',
+    'forex',
+    'other',
+] as const satisfies readonly PortfolioAssetClass[]
+
+export const PORTFOLIO_MOVEMENT_TYPES = [
+    'buy',
+    'sell',
+    'deposit',
+    'withdrawal',
+    'dividend',
+    'interest',
+    'fee',
+    'tax',
+    'transfer_in',
+    'transfer_out',
+    'split',
+    'fx_adjustment',
+    'manual_adjustment',
+] as const satisfies readonly PortfolioMovementType[]
+
+export const PORTFOLIO_VALUATION_STATUSES = [
+    'market',
+    'manual',
+    'stale',
+    'missing',
+    'error',
+] as const satisfies readonly PortfolioValuationStatus[]
+
+export const PORTFOLIO_GROUPING_KEYS = [
+    'asset',
+    'account',
+    'assetClass',
+    'sector',
+    'geography',
+    'currency',
+] as const satisfies readonly PortfolioGroupingKey[]
+
+export const PORTFOLIO_INCOME_TYPES = [
+    'dividend',
+    'interest',
+    'distribution',
+    'staking',
+    'rent',
+    'other',
+] as const satisfies readonly PortfolioIncomeType[]
+
+export const PORTFOLIO_FEE_TYPES = [
+    'brokerage',
+    'management',
+    'custody',
+    'fx',
+    'tax',
+    'other',
+] as const satisfies readonly PortfolioFeeType[]
+
+export const PORTFOLIO_VALUATION_STATUS_LABELS: Record<PortfolioValuationStatus, string> = {
+    market: 'wealth.portfolio.valuationStatuses.market',
+    manual: 'wealth.portfolio.valuationStatuses.manual',
+    stale: 'wealth.portfolio.valuationStatuses.stale',
+    missing: 'wealth.portfolio.valuationStatuses.missing',
+    error: 'wealth.portfolio.valuationStatuses.error',
+}
+
+export const PORTFOLIO_GROUPING_KEY_LABELS: Record<PortfolioGroupingKey, string> = {
+    asset: 'wealth.portfolio.grouping.asset',
+    account: 'wealth.portfolio.grouping.account',
+    assetClass: 'wealth.portfolio.grouping.assetClass',
+    sector: 'wealth.portfolio.grouping.sector',
+    geography: 'wealth.portfolio.grouping.geography',
+    currency: 'wealth.portfolio.grouping.currency',
+}
+
+export interface PortfolioAsset {
+    id: PortfolioAssetId
+    symbol: string | null
+    name: string
+    assetClass: PortfolioAssetClass
+    sector: string | null
+    geography: string | null
+    currency: PortfolioCurrencyCode
+    marketInstrumentId: PortfolioId | null
+    isActive: boolean
+    note: string | null
+}
+
+export interface PortfolioPosition {
+    id: PortfolioId
+    accountId: PortfolioAccountId
+    accountName: string
+    assetId: PortfolioAssetId
+    asset: PortfolioAsset | null
+    quantity: number
+    averageCost: number | null
+    bookValue: number | null
+    marketValue: number | null
+    currency: PortfolioCurrencyCode
+    valuationStatus: PortfolioValuationStatus
+    valuedAt: PortfolioDateTimeString | null
+    allocationPercent: number
+    unrealizedGainLoss: PortfolioGainLoss | null
+}
+
+export interface PortfolioMovement {
+    id: PortfolioId
+    accountId: PortfolioAccountId
+    assetId: PortfolioAssetId | null
+    type: PortfolioMovementType
+    quantity: number | null
+    unitPrice: number | null
+    grossAmount: number
+    feeAmount: number
+    taxAmount: number
+    netAmount: number
+    currency: PortfolioCurrencyCode
+    tradeDate: PortfolioDateString
+    settledAt: PortfolioDateString | null
+    note: string | null
+}
+
+export interface PortfolioValuation {
+    assetId: PortfolioAssetId | null
+    accountId: PortfolioAccountId | null
+    quantity: number
+    unitPrice: number | null
+    marketValue: number | null
+    bookValue: number | null
+    currency: PortfolioCurrencyCode
+    status: PortfolioValuationStatus
+    valuedAt: PortfolioDateTimeString | null
+    source: 'market_data' | 'manual' | 'imported' | 'derived' | 'none'
+    warnings: string[]
+}
+
+export interface PortfolioGainLoss {
+    absolute: number
+    percent: number | null
+    currency: PortfolioCurrencyCode
+    realized: boolean
+}
+
+export interface PortfolioAllocation {
+    groupBy: PortfolioGroupingKey
+    key: string
+    label: string
+    marketValue: number
+    currency: PortfolioCurrencyCode
+    allocationPercent: number
+    positionsCount: number
+}
+
+export interface PortfolioIncome {
+    id: PortfolioId
+    accountId: PortfolioAccountId
+    assetId: PortfolioAssetId | null
+    type: PortfolioIncomeType
+    amount: number
+    currency: PortfolioCurrencyCode
+    paidAt: PortfolioDateString
+    withholdingTaxAmount: number
+    note: string | null
+}
+
+export interface PortfolioFee {
+    id: PortfolioId
+    accountId: PortfolioAccountId
+    assetId: PortfolioAssetId | null
+    type: PortfolioFeeType
+    amount: number
+    currency: PortfolioCurrencyCode
+    chargedAt: PortfolioDateString
+    note: string | null
+}
+
+export interface PortfolioSnapshot {
+    id: PortfolioId
+    baseCurrency: PortfolioCurrencyCode
+    capturedAt: PortfolioDateTimeString
+    totalMarketValue: number
+    totalBookValue: number
+    totalGainLoss: PortfolioGainLoss
+    positions: PortfolioPosition[]
+    allocations: PortfolioAllocation[]
+    income: PortfolioIncome[]
+    fees: PortfolioFee[]
+    valuationStatus: PortfolioValuationStatus
+    warnings: string[]
+}
+
+export interface PortfolioAllocationInput {
+    key: string
+    label?: string | null
+    marketValue: number
+    currency?: PortfolioCurrencyCode | null
+    positionsCount?: number
+}
+
+export interface PortfolioAllocationPercentageResult extends Required<Omit<PortfolioAllocationInput, 'currency'>> {
+    currency: PortfolioCurrencyCode
+    allocationPercent: number
+}
+
+export interface PortfolioAggregateResult<TItem> {
+    key: string
+    items: TItem[]
+    count: number
+    total: number
+}
+
+export function normalizePortfolioCurrency(
+    currency: string | null | undefined,
+    fallback: PortfolioCurrencyCode = 'CAD',
+): PortfolioCurrencyCode {
+    const normalized = String(currency || '')
+        .trim()
+        .toUpperCase()
+
+    return /^[A-Z]{3}$/.test(normalized) ? normalized : fallback.trim().toUpperCase()
+}
+
+export function roundPortfolioMoney(amount: number | null | undefined, precision = 2): number {
+    if (!Number.isFinite(amount)) return 0
+
+    const safePrecision = Number.isInteger(precision) ? Math.min(Math.max(precision, 0), 8) : 2
+    const factor = 10 ** safePrecision
+
+    return Math.round((Number(amount) + Number.EPSILON) * factor) / factor
+}
+
+export function calculatePortfolioGainLoss(
+    marketValue: number | null | undefined,
+    bookValue: number | null | undefined,
+    currency: PortfolioCurrencyCode,
+    realized = false,
+): PortfolioGainLoss {
+    const safeMarketValue = Number.isFinite(marketValue) ? Number(marketValue) : 0
+    const safeBookValue = Number.isFinite(bookValue) ? Number(bookValue) : 0
+    const absolute = roundPortfolioMoney(safeMarketValue - safeBookValue)
+
+    return {
+        absolute,
+        percent: safeBookValue === 0 ? null : roundPortfolioMoney((absolute / safeBookValue) * 100, 4),
+        currency: normalizePortfolioCurrency(currency),
+        realized,
+    }
+}
+
+export function calculatePortfolioAllocationPercentages(
+    items: PortfolioAllocationInput[],
+    baseCurrency: PortfolioCurrencyCode = 'CAD',
+    explicitTotal?: number | null,
+): PortfolioAllocationPercentageResult[] {
+    const total = Number.isFinite(explicitTotal)
+        ? Number(explicitTotal)
+        : items.reduce((sum, item) => sum + Math.max(0, item.marketValue || 0), 0)
+
+    return items.map((item) => ({
+        key: item.key,
+        label: item.label || item.key,
+        marketValue: roundPortfolioMoney(item.marketValue),
+        currency: normalizePortfolioCurrency(item.currency, baseCurrency),
+        positionsCount: item.positionsCount || 0,
+        allocationPercent: total > 0 ? roundPortfolioMoney((Math.max(0, item.marketValue || 0) / total) * 100, 4) : 0,
+    }))
+}
+
+export function aggregatePortfolioByKey<TItem>(
+    items: TItem[],
+    keySelector: (item: TItem) => string | null | undefined,
+    valueSelector: (item: TItem) => number | null | undefined,
+    fallbackKey = 'unclassified',
+): PortfolioAggregateResult<TItem>[] {
+    const groups = new Map<string, PortfolioAggregateResult<TItem>>()
+
+    for (const item of items) {
+        const rawKey = keySelector(item)
+        const key = rawKey && rawKey.trim() ? rawKey.trim() : fallbackKey
+        const value = Number(valueSelector(item))
+        const amount = Number.isFinite(value) ? value : 0
+        const group = groups.get(key) || {key, items: [], count: 0, total: 0}
+
+        group.items.push(item)
+        group.count += 1
+        group.total = roundPortfolioMoney(group.total + amount)
+        groups.set(key, group)
+    }
+
+    return [...groups.values()].sort((left, right) => right.total - left.total || left.key.localeCompare(right.key))
+}
+
+export function isPortfolioValuationStatus(value: string): value is PortfolioValuationStatus {
+    return PORTFOLIO_VALUATION_STATUSES.includes(value as PortfolioValuationStatus)
+}
+
+export function isPortfolioGroupingKey(value: string): value is PortfolioGroupingKey {
+    return PORTFOLIO_GROUPING_KEYS.includes(value as PortfolioGroupingKey)
+}


### PR DESCRIPTION
## Summary

Closes #42.

- Add pure shared TypeScript contracts for portfolio assets, positions, movements, valuations, gain/loss, allocations, income, fees and snapshots.
- Add explicit portfolio valuation statuses (`market`, `manual`, `stale`, `missing`, `error`) and grouping keys for asset, account, asset class, sector, geography and currency.
- Add pure helpers for currency normalization, money rounding, gain/loss, allocation percentages and aggregation by key.
- Add Vitest coverage for the contracts and helpers.
- Document MVP portfolio analytics calculation conventions.

## Validation

- Local TypeScript transpilation check of `src/types/portfolio.ts` and `src/test/types/portfolio.test.ts` passed in the sandbox.
- Runtime smoke check of the pure helpers passed in the sandbox.

I could not run the repository's full `npm run check` locally because the sandbox cannot clone or install from GitHub/network, so CI should be treated as the source of truth.