### PR TITLE
Add portfolio gain metrics

### DIFF
--- a/docs/portfolio-gain-metrics.md
+++ b/docs/portfolio-gain-metrics.md
@@ -1,0 +1,55 @@
+# Portfolio gain metrics MVP
+
+Cette note décrit la méthode retenue pour les gains/pertes du dashboard portefeuille MVP.
+
+## Méthode retenue
+
+Le MVP utilise le **coût moyen pondéré** par position.
+
+- Un achat augmente la quantité détenue et le coût de revient.
+- Les frais d'achat sont inclus dans le coût de revient par défaut.
+- Une vente retire une partie du coût de revient au coût moyen courant.
+- Le gain réalisé simple vaut : `produit net de vente - coût moyen retiré`.
+- Le produit net de vente déduit les frais de vente.
+- La plus-value latente vaut : `valeur actuelle - coût restant`.
+
+Cette méthode est volontairement simple et déterministe. Elle évite de gérer des lots fiscaux dans le MVP tout en donnant des chiffres lisibles pour l'utilisateur.
+
+## Définitions
+
+### Plus-value latente par position
+
+```text
+unrealizedGain = currentValue - remainingAverageCostBasis
+unrealizedGainPercent = unrealizedGain / remainingAverageCostBasis
+```
+
+Elle n'est calculée que si la position a une valeur actuelle. Une position sans prix de marché ni fallback manuel garde `unrealizedGainLoss = null`, afin de ne pas afficher un faux gain.
+
+### Plus-value réalisée simple
+
+```text
+realizedGain = netSaleProceeds - removedAverageCostBasis
+```
+
+Le coût retiré lors d'une vente partielle est calculé avec le coût moyen pondéré juste avant la vente.
+
+### Rendement brut simple
+
+```text
+grossReturnSimple = (totalUnrealizedGain + realizedGainSimple) / totalCostBasis
+```
+
+Le rendement brut simple n'est pas un TWR, un MWR, un IRR ou un XIRR. Il ne tient pas compte du timing exact des flux; il sert seulement d'indicateur lisible dans le MVP.
+
+## Position fermée
+
+Une position fermée a une quantité à `0`, un coût restant à `0` et peut conserver un gain réalisé. Sa plus-value latente est `0` et son gain/perte total correspond au gain réalisé simple.
+
+## Limites assumées
+
+- Pas de FIFO/LIFO configurable.
+- Pas de fiscalité des gains en capital.
+- Pas de lots fiscaux avancés.
+- Pas de rendement annualisé.
+- Pas de TWR/IRR/XIRR.

--- a/electron/portfolio/portfolioMetricsService.js
+++ b/electron/portfolio/portfolioMetricsService.js
@@ -1,0 +1,331 @@
+const {convertAmountWithFx} = require('../marketData/fxConversion')
+const {calculatePortfolioValuation, roundMoney} = require('./portfolioValuationService')
+
+const BUY = new Set(['BUY', 'buy'])
+const SELL = new Set(['SELL', 'sell'])
+
+const text = (value) => typeof value === 'string' && value.trim() ? value.trim() : null
+const currency = (value, fallback = 'CAD') => (text(value) || fallback).toUpperCase()
+const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback
+const maybeNumber = (value) => value == null || value === '' || !Number.isFinite(Number(value)) ? null : Number(value)
+const date = (value, fallback = new Date()) => {
+    const parsed = value instanceof Date ? new Date(value.getTime()) : new Date(value == null || value === '' ? fallback : value)
+    return Number.isNaN(parsed.getTime()) ? fallback : parsed
+}
+
+function movementType(movement) {
+    return text(movement?.type)?.toUpperCase() || 'UNKNOWN'
+}
+
+function movementDate(movement) {
+    return movement.operationDate ?? movement.tradeDate ?? movement.date ?? movement.createdAt
+}
+
+function movementSortKey(movement) {
+    return date(movementDate(movement), new Date(0)).getTime()
+}
+
+function positionInstrumentId(position) {
+    return maybeNumber(position.instrumentId ?? position.investmentInstrumentId ?? position.assetId)
+}
+
+function positionAccountId(position) {
+    return maybeNumber(position.accountId ?? position.account?.id)
+}
+
+function movementBelongsToPosition(movement, position) {
+    const movementPositionId = maybeNumber(movement.positionId ?? movement.investmentPositionId)
+    if (movementPositionId != null && movementPositionId === maybeNumber(position.id)) return true
+
+    const movementInstrumentId = maybeNumber(movement.instrumentId ?? movement.investmentInstrumentId ?? movement.assetId)
+    const movementAccountId = maybeNumber(movement.accountId ?? movement.account?.id)
+    const instrumentId = positionInstrumentId(position)
+    const accountId = positionAccountId(position)
+
+    return movementInstrumentId != null &&
+        instrumentId != null &&
+        movementInstrumentId === instrumentId &&
+        (movementAccountId == null || accountId == null || movementAccountId === accountId)
+}
+
+function movementCashAmount(movement) {
+    const cash = maybeNumber(movement.cashAmount)
+    if (cash != null) return Math.abs(cash)
+
+    const quantity = maybeNumber(movement.quantity)
+    const unitPrice = maybeNumber(movement.unitPrice)
+    return quantity != null && unitPrice != null ? Math.abs(quantity * unitPrice) : 0
+}
+
+async function safeConvertAmount(amount, from, to, at, options = {}) {
+    try {
+        const fxRate = await convertAmountWithFx(
+            {amount: numberOr(amount), from: currency(from, to), to: currency(to, from), date: at},
+            {rates: options.fxRates, resolver: options.fxRateResolver},
+        )
+        return {amount: fxRate.convertedAmount, fxRate, error: null}
+    } catch (error) {
+        return {amount: null, fxRate: null, error}
+    }
+}
+
+async function convertMovementCash(movement, baseCurrency, options = {}) {
+    const cashCurrency = currency(movement.cashCurrency ?? movement.priceCurrency, baseCurrency)
+    return safeConvertAmount(movementCashAmount(movement), cashCurrency, baseCurrency, movementDate(movement), options)
+}
+
+async function convertMovementFee(movement, baseCurrency, options = {}) {
+    const feeCurrency = currency(movement.feeCurrency ?? movement.cashCurrency ?? movement.priceCurrency, baseCurrency)
+    return safeConvertAmount(Math.abs(numberOr(movement.feeAmount)), feeCurrency, baseCurrency, movementDate(movement), options)
+}
+
+/**
+ * Weighted-average-cost ledger for the MVP.
+ *
+ * BUY increases quantity and cost basis. Buy fees are included in cost by default.
+ * SELL removes cost basis at the average cost currently carried by the position,
+ * then realizes proceeds minus sale fees minus removed basis.
+ */
+async function calculateWeightedAveragePositionMetrics(position, movements = [], options = {}) {
+    const baseCurrency = currency(options.baseCurrency)
+    const asOf = date(options.asOf)
+    const includeBuyFees = options.includeBuyFeesInCost !== false
+    const relatedMovements = movements
+        .filter((movement) => movementBelongsToPosition(movement, position))
+        .filter((movement) => movementSortKey(movement) <= asOf.getTime())
+        .sort((left, right) => movementSortKey(left) - movementSortKey(right) || numberOr(left.id) - numberOr(right.id))
+
+    let quantity = 0
+    let remainingCost = 0
+    let realizedGain = 0
+    let realizedCostBasis = 0
+    let realizedProceeds = 0
+    const warnings = []
+
+    for (const movement of relatedMovements) {
+        const type = movementType(movement)
+        const quantityDelta = Math.abs(numberOr(movement.quantity))
+        const cash = await convertMovementCash(movement, baseCurrency, options)
+        const fee = await convertMovementFee(movement, baseCurrency, options)
+
+        if (cash.error) warnings.push(`Conversion FX indisponible pour le mouvement ${movement.id || 'sans id'}.`)
+        if (fee.error) warnings.push(`Conversion FX des frais indisponible pour le mouvement ${movement.id || 'sans id'}.`)
+
+        const convertedCash = cash.amount ?? 0
+        const convertedFee = fee.amount ?? 0
+
+        if (BUY.has(type)) {
+            quantity += quantityDelta
+            remainingCost += convertedCash + (includeBuyFees ? convertedFee : 0)
+        } else if (SELL.has(type)) {
+            const soldQuantity = Math.min(quantity, quantityDelta)
+            const averageCost = quantity > 0 ? remainingCost / quantity : 0
+            const removedCostBasis = averageCost * soldQuantity
+            const netProceeds = convertedCash - convertedFee
+
+            quantity = Math.max(0, quantity - soldQuantity)
+            remainingCost = quantity === 0 ? 0 : Math.max(0, remainingCost - removedCostBasis)
+            realizedCostBasis += removedCostBasis
+            realizedProceeds += netProceeds
+            realizedGain += netProceeds - removedCostBasis
+        }
+    }
+
+    if (!relatedMovements.length) {
+        const fallbackQuantity = numberOr(position.quantity)
+        const fallbackCost = maybeNumber(position.costBasis ?? position.bookValue)
+        return {
+            method: 'weighted_average',
+            quantity: roundMoney(fallbackQuantity, 8),
+            remainingCost: roundMoney(fallbackCost ?? 0),
+            averageCost: fallbackQuantity > 0 && fallbackCost != null ? roundMoney(fallbackCost / fallbackQuantity, 6) : null,
+            realizedGain: 0,
+            realizedGainPercent: null,
+            realizedCostBasis: 0,
+            realizedProceeds: 0,
+            totalCostBasis: roundMoney(fallbackCost ?? 0),
+            closed: fallbackQuantity === 0,
+            movements: relatedMovements,
+            warnings,
+        }
+    }
+
+    const realizedGainPercent = realizedCostBasis > 0 ? roundMoney((realizedGain / realizedCostBasis) * 100, 4) : null
+
+    return {
+        method: 'weighted_average',
+        quantity: roundMoney(quantity, 8),
+        remainingCost: roundMoney(remainingCost),
+        averageCost: quantity > 0 ? roundMoney(remainingCost / quantity, 6) : null,
+        realizedGain: roundMoney(realizedGain),
+        realizedGainPercent,
+        realizedCostBasis: roundMoney(realizedCostBasis),
+        realizedProceeds: roundMoney(realizedProceeds),
+        totalCostBasis: roundMoney(remainingCost + realizedCostBasis),
+        closed: quantity === 0,
+        movements: relatedMovements,
+        warnings,
+    }
+}
+
+function createGainLoss(amount, percent, currencyCode, realized = false) {
+    return {
+        absolute: roundMoney(amount),
+        percent: percent == null ? null : roundMoney(percent, 4),
+        currency: currencyCode,
+        realized,
+    }
+}
+
+function calculateUnrealizedGain(positionValuation, costMetrics, baseCurrency) {
+    if (costMetrics.quantity === 0) return createGainLoss(0, null, baseCurrency, false)
+    if (positionValuation.marketValue == null) return null
+
+    const absolute = roundMoney(positionValuation.marketValue - costMetrics.remainingCost)
+    const percent = costMetrics.remainingCost > 0 ? (absolute / costMetrics.remainingCost) * 100 : null
+    return createGainLoss(absolute, percent, baseCurrency, false)
+}
+
+function enrichPositionWithGainMetrics(positionValuation, costMetrics, baseCurrency) {
+    const unrealized = calculateUnrealizedGain(positionValuation, costMetrics, baseCurrency)
+    const realized = createGainLoss(costMetrics.realizedGain, costMetrics.realizedGainPercent, baseCurrency, true)
+    const totalAmount = roundMoney((unrealized?.absolute ?? 0) + realized.absolute)
+    const totalDenominator = costMetrics.totalCostBasis
+    const totalPercent = totalDenominator > 0 ? (totalAmount / totalDenominator) * 100 : null
+
+    return {
+        ...positionValuation,
+        quantity: costMetrics.quantity,
+        quantityHeld: costMetrics.quantity,
+        averageCost: costMetrics.averageCost,
+        bookValue: costMetrics.remainingCost,
+        investedCost: costMetrics.remainingCost,
+        unrealizedGainLoss: unrealized,
+        unrealizedGain: unrealized?.absolute ?? null,
+        unrealizedGainPercent: unrealized?.percent ?? null,
+        realizedGainLoss: realized,
+        realizedGainSimple: realized.absolute,
+        realizedGainPercent: realized.percent,
+        totalGainLoss: createGainLoss(totalAmount, totalPercent, baseCurrency, false),
+        gainLossTotal: totalAmount,
+        costMethod: costMetrics.method,
+        realizedCostBasis: costMetrics.realizedCostBasis,
+        realizedProceeds: costMetrics.realizedProceeds,
+        totalCostBasis: costMetrics.totalCostBasis,
+        isClosed: costMetrics.closed,
+        warnings: [...(positionValuation.warnings || []), ...costMetrics.warnings],
+    }
+}
+
+function summarizeGainMetrics(positions, baseCurrency) {
+    const totalUnrealizedGain = roundMoney(
+        positions.reduce((sum, position) => sum + (position.unrealizedGainLoss?.absolute ?? 0), 0),
+    )
+    const unrealizedCostBasis = roundMoney(
+        positions.reduce((sum, position) => position.unrealizedGainLoss == null ? sum : sum + position.investedCost, 0),
+    )
+    const realizedGainSimple = roundMoney(
+        positions.reduce((sum, position) => sum + (position.realizedGainLoss?.absolute ?? 0), 0),
+    )
+    const realizedCostBasis = roundMoney(
+        positions.reduce((sum, position) => sum + (position.realizedCostBasis || 0), 0),
+    )
+    const totalGainLoss = roundMoney(totalUnrealizedGain + realizedGainSimple)
+    const totalCostBasis = roundMoney(unrealizedCostBasis + realizedCostBasis)
+    const grossReturnSimple = totalCostBasis > 0 ? roundMoney((totalGainLoss / totalCostBasis) * 100, 4) : null
+
+    return {
+        currency: baseCurrency,
+        totalUnrealizedGain,
+        totalUnrealizedGainPercent: unrealizedCostBasis > 0
+            ? roundMoney((totalUnrealizedGain / unrealizedCostBasis) * 100, 4)
+            : null,
+        realizedGainSimple,
+        realizedGainPercent: realizedCostBasis > 0
+            ? roundMoney((realizedGainSimple / realizedCostBasis) * 100, 4)
+            : null,
+        totalGainLoss,
+        grossReturnSimple,
+        grossReturnSimplePercent: grossReturnSimple,
+        unrealizedCostBasis,
+        realizedCostBasis,
+        totalCostBasis,
+        valuedPositionsCount: positions.filter((position) => position.unrealizedGainLoss != null).length,
+        incompletePositionsCount: positions.filter((position) => position.unrealizedGainLoss == null).length,
+    }
+}
+
+function applyAllocationPercentages(positions, totalMarketValue) {
+    return positions.map((position) => ({
+        ...position,
+        allocationPercent: totalMarketValue > 0 && position.marketValue != null
+            ? roundMoney((position.marketValue / totalMarketValue) * 100, 4)
+            : 0,
+    }))
+}
+
+async function calculatePortfolioMetrics(input = {}, dependencies = {}) {
+    const baseCurrency = currency(input.baseCurrency ?? input.currency ?? dependencies.baseCurrency, 'CAD')
+    const asOf = date(input.asOf ?? dependencies.asOf ?? dependencies.now?.() ?? new Date())
+    const options = {
+        ...dependencies,
+        ...input,
+        baseCurrency,
+        asOf,
+        fxRates: input.fxRates ?? dependencies.fxRates,
+        fxRateResolver: input.fxRateResolver ?? dependencies.fxRateResolver,
+    }
+    const valuation = input.valuation || await calculatePortfolioValuation({...input, baseCurrency, asOf}, dependencies)
+    const sourcePositions = Array.isArray(input.positions) ? input.positions : []
+    const movements = Array.isArray(input.movements) ? input.movements : []
+    const enriched = []
+
+    for (const positionValuation of valuation.positions || []) {
+        const sourcePosition = sourcePositions.find((position) => maybeNumber(position.id) === maybeNumber(positionValuation.id)) || positionValuation
+        const costMetrics = await calculateWeightedAveragePositionMetrics(sourcePosition, movements, options)
+        enriched.push(enrichPositionWithGainMetrics(positionValuation, costMetrics, baseCurrency))
+    }
+
+    const totalMarketValue = roundMoney(enriched.reduce((sum, position) => sum + (position.marketValue ?? 0), 0))
+    const positions = applyAllocationPercentages(enriched, totalMarketValue)
+    const gainMetrics = summarizeGainMetrics(positions, baseCurrency)
+
+    return {
+        ...valuation,
+        baseCurrency,
+        asOf: asOf.toISOString(),
+        positions,
+        totals: {
+            ...(valuation.totals || {}),
+            totalMarketValue,
+            totalInvestedCost: roundMoney(positions.reduce((sum, position) => sum + position.investedCost, 0)),
+            totalUnrealizedGain: gainMetrics.totalUnrealizedGain,
+            totalUnrealizedGainPercent: gainMetrics.totalUnrealizedGainPercent,
+            realizedGainSimple: gainMetrics.realizedGainSimple,
+            realizedGainPercent: gainMetrics.realizedGainPercent,
+            totalGainLoss: gainMetrics.totalGainLoss,
+            grossReturnSimple: gainMetrics.grossReturnSimple,
+            grossReturnSimplePercent: gainMetrics.grossReturnSimplePercent,
+        },
+        gainMetrics,
+        warnings: [
+            ...(valuation.warnings || []),
+            ...positions.flatMap((position) => (position.warnings || []).map((warning) => ({positionId: position.id, warning}))),
+        ],
+    }
+}
+
+function createPortfolioMetricsService(dependencies = {}) {
+    return {
+        calculatePortfolioMetrics: (input = {}) => calculatePortfolioMetrics(input, dependencies),
+        calculateWeightedAveragePositionMetrics: (position, movements = [], options = {}) =>
+            calculateWeightedAveragePositionMetrics(position, movements, {...dependencies, ...options}),
+    }
+}
+
+module.exports = {
+    calculatePortfolioMetrics,
+    calculateWeightedAveragePositionMetrics,
+    createPortfolioMetricsService,
+    summarizeGainMetrics,
+}

--- a/src/test/electron/portfolioMetricsService.test.js
+++ b/src/test/electron/portfolioMetricsService.test.js
@@ -1,0 +1,217 @@
+const {describe, expect, it} = require('vitest')
+const {
+    calculatePortfolioMetrics,
+    calculateWeightedAveragePositionMetrics,
+} = require('../../../electron/portfolio/portfolioMetricsService')
+
+function position(overrides = {}) {
+    return {
+        id: 1,
+        accountId: 10,
+        accountName: 'Brokerage',
+        instrumentId: 100,
+        marketInstrumentId: 500,
+        quantity: 0,
+        currency: 'CAD',
+        instrument: {
+            id: 100,
+            symbol: 'XEQT',
+            name: 'XEQT',
+            assetClass: 'ETF',
+            currency: 'CAD',
+            marketInstrumentId: 500,
+        },
+        ...overrides,
+    }
+}
+
+function buy(id, quantity, unitPrice, feeAmount = 0, extra = {}) {
+    return {
+        id,
+        type: 'BUY',
+        positionId: 1,
+        quantity,
+        unitPrice,
+        priceCurrency: 'CAD',
+        feeAmount,
+        feeCurrency: 'CAD',
+        operationDate: `2026-01-0${id}`,
+        ...extra,
+    }
+}
+
+function sell(id, quantity, unitPrice, feeAmount = 0, extra = {}) {
+    return {
+        id,
+        type: 'SELL',
+        positionId: 1,
+        quantity,
+        unitPrice,
+        priceCurrency: 'CAD',
+        feeAmount,
+        feeCurrency: 'CAD',
+        operationDate: `2026-02-0${id}`,
+        ...extra,
+    }
+}
+
+describe('portfolio metrics service', () => {
+    it('calculates unrealized gain for a single buy', async () => {
+        const result = await calculatePortfolioMetrics({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [position()],
+            movements: [buy(1, 10, 100, 0)],
+            priceSnapshots: [
+                {id: 1, marketInstrumentId: 500, unitPrice: 120, currency: 'CAD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+            ],
+        })
+
+        expect(result.positions[0]).toMatchObject({
+            quantityHeld: 10,
+            averageCost: 100,
+            investedCost: 1000,
+            marketValue: 1200,
+            unrealizedGain: 200,
+            unrealizedGainPercent: 20,
+            realizedGainSimple: 0,
+            gainLossTotal: 200,
+            costMethod: 'weighted_average',
+            isClosed: false,
+        })
+        expect(result.totals).toMatchObject({
+            totalUnrealizedGain: 200,
+            totalUnrealizedGainPercent: 20,
+            realizedGainSimple: 0,
+            totalGainLoss: 200,
+            grossReturnSimple: 20,
+        })
+    })
+
+    it('uses weighted average cost across multiple buys', async () => {
+        const result = await calculatePortfolioMetrics({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [position()],
+            movements: [buy(1, 10, 100, 0), buy(2, 10, 140, 0)],
+            priceSnapshots: [
+                {id: 1, marketInstrumentId: 500, unitPrice: 150, currency: 'CAD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+            ],
+        })
+
+        expect(result.positions[0]).toMatchObject({
+            quantityHeld: 20,
+            averageCost: 120,
+            investedCost: 2400,
+            marketValue: 3000,
+            unrealizedGain: 600,
+            unrealizedGainPercent: 25,
+        })
+    })
+
+    it('handles partial sells by removing cost basis at weighted average cost', async () => {
+        const result = await calculatePortfolioMetrics({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [position()],
+            movements: [
+                buy(1, 10, 100, 0),
+                buy(2, 10, 140, 0),
+                sell(3, 5, 160, 10, {operationDate: '2026-03-01'}),
+            ],
+            priceSnapshots: [
+                {id: 1, marketInstrumentId: 500, unitPrice: 150, currency: 'CAD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+            ],
+        })
+
+        expect(result.positions[0]).toMatchObject({
+            quantityHeld: 15,
+            averageCost: 120,
+            investedCost: 1800,
+            marketValue: 2250,
+            unrealizedGain: 450,
+            realizedCostBasis: 600,
+            realizedProceeds: 790,
+            realizedGainSimple: 190,
+            gainLossTotal: 640,
+        })
+        expect(result.gainMetrics).toMatchObject({
+            totalUnrealizedGain: 450,
+            realizedGainSimple: 190,
+            totalGainLoss: 640,
+            grossReturnSimple: 26.6667,
+        })
+    })
+
+    it('keeps closed positions with realized gain and zero unrealized gain', async () => {
+        const result = await calculatePortfolioMetrics({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [position()],
+            movements: [buy(1, 10, 100, 0), sell(2, 10, 130, 0)],
+            priceSnapshots: [
+                {id: 1, marketInstrumentId: 500, unitPrice: 999, currency: 'CAD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+            ],
+        })
+
+        expect(result.positions[0]).toMatchObject({
+            quantityHeld: 0,
+            investedCost: 0,
+            marketValue: 0,
+            unrealizedGain: 0,
+            realizedGainSimple: 300,
+            gainLossTotal: 300,
+            isClosed: true,
+        })
+        expect(result.totals).toMatchObject({
+            totalUnrealizedGain: 0,
+            realizedGainSimple: 300,
+            totalGainLoss: 300,
+            grossReturnSimple: 30,
+        })
+    })
+
+    it('does not invent unrealized gains for positions without a price', async () => {
+        const result = await calculatePortfolioMetrics({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [position({marketInstrumentId: null, instrument: {symbol: 'PRIVATE', name: 'Private asset', assetClass: 'OTHER', currency: 'CAD', marketInstrumentId: null}})],
+            movements: [buy(1, 4, 100, 0)],
+            priceSnapshots: [],
+        })
+
+        expect(result.positions[0]).toMatchObject({
+            quantityHeld: 4,
+            investedCost: 400,
+            marketValue: null,
+            unrealizedGain: null,
+            unrealizedGainPercent: null,
+            realizedGainSimple: 0,
+            gainLossTotal: 0,
+            valuationStatus: 'missing',
+        })
+        expect(result.gainMetrics).toMatchObject({
+            totalUnrealizedGain: 0,
+            totalUnrealizedGainPercent: null,
+            incompletePositionsCount: 1,
+        })
+    })
+
+    it('can calculate weighted-average metrics without running full portfolio valuation', async () => {
+        const metrics = await calculateWeightedAveragePositionMetrics(
+            position(),
+            [buy(1, 3, 100, 3), buy(2, 1, 130, 1), sell(3, 2, 150, 2)],
+            {baseCurrency: 'CAD', asOf: '2026-04-30'},
+        )
+
+        expect(metrics).toMatchObject({
+            quantity: 2,
+            remainingCost: 217,
+            averageCost: 108.5,
+            realizedCostBasis: 217,
+            realizedProceeds: 298,
+            realizedGain: 81,
+            realizedGainPercent: 37.3272,
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Closes #44.

- Add a portfolio metrics service on top of the existing portfolio valuation service.
- Calculate per-position unrealized gain/loss, unrealized percentage, weighted average cost, current value and total gain/loss.
- Calculate portfolio-level total unrealized gain, unrealized percentage, simple realized gain and simple gross return.
- Use an explicit weighted-average-cost method for partial sells.
- Keep positions without a price from showing fake gains.
- Document the MVP cost method and its limits.
- Add unit tests for a single buy, multiple buys, partial sell, closed position and incomplete position.

## Validation

- Added Vitest unit coverage for the new service.
- I could not run the repository's full `npm run check` locally because the sandbox does not have the repo dependencies installed. CI should be treated as source of truth.

Base branch: `epic4`.