### PR TITLE
Add portfolio allocation engine

### DIFF
--- a/electron/portfolio/portfolioAllocationService.js
+++ b/electron/portfolio/portfolioAllocationService.js
@@ -1,0 +1,250 @@
+const {calculatePortfolioMetrics} = require('./portfolioMetricsService')
+const {roundMoney} = require('./portfolioValuationService')
+
+const GROUPING_KEYS = ['asset', 'account', 'assetClass', 'sector', 'geography', 'currency']
+const UNKNOWN_KEY = 'unknown'
+const UNKNOWN_LABEL = 'Non classé'
+
+const text = (value) => typeof value === 'string' && value.trim() ? value.trim() : null
+const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback
+const maybeNumber = (value) => value == null || value === '' || !Number.isFinite(Number(value)) ? null : Number(value)
+const currency = (value, fallback = 'CAD') => (text(value) || fallback).toUpperCase()
+
+function slug(value) {
+    const normalized = text(value)
+    if (!normalized) return UNKNOWN_KEY
+
+    return normalized
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '') || UNKNOWN_KEY
+}
+
+function known(value) {
+    const normalized = text(value)
+    return normalized && !['unknown', 'non classe', 'non classé', 'n/a', 'na', 'none', 'null'].includes(slug(normalized))
+}
+
+function hasMarketValue(position) {
+    return position?.marketValue != null && Number.isFinite(Number(position.marketValue)) && Number(position.marketValue) > 0
+}
+
+function positionValue(position) {
+    return hasMarketValue(position) ? Math.max(0, Number(position.marketValue)) : 0
+}
+
+function positionCompleteness(position) {
+    if (!hasMarketValue(position)) return 'missing_value'
+    return 'complete'
+}
+
+function assetInfo(position) {
+    return position?.asset || position?.instrument || {}
+}
+
+function assetId(position) {
+    return maybeNumber(position?.assetId ?? assetInfo(position).id ?? position?.instrumentId ?? position?.id)
+}
+
+function accountId(position) {
+    return maybeNumber(position?.accountId ?? position?.account?.id)
+}
+
+function createGroupIdentity(position, groupBy) {
+    const asset = assetInfo(position)
+
+    if (groupBy === 'asset') {
+        const id = assetId(position)
+        const symbol = text(asset.symbol ?? position.symbol)
+        const name = text(asset.name ?? position.name)
+
+        if (id != null || symbol || name) {
+            return {
+                key: id != null ? String(id) : slug(symbol || name),
+                label: name || symbol || `Actif ${id}`,
+                rawKey: id ?? symbol ?? name,
+                isUnknown: false,
+            }
+        }
+    }
+
+    if (groupBy === 'account') {
+        const id = accountId(position)
+        const name = text(position.accountName ?? position.account?.name)
+
+        if (id != null || name) {
+            return {
+                key: id != null ? String(id) : slug(name),
+                label: name || `Compte ${id}`,
+                rawKey: id ?? name,
+                isUnknown: false,
+            }
+        }
+    }
+
+    if (groupBy === 'assetClass') {
+        const value = asset.assetClass ?? position.assetClass
+        if (known(value)) return {key: slug(value), label: text(value), rawKey: value, isUnknown: false}
+    }
+
+    if (groupBy === 'sector') {
+        const value = asset.sector ?? position.sector
+        if (known(value)) return {key: slug(value), label: text(value), rawKey: value, isUnknown: false}
+    }
+
+    if (groupBy === 'geography') {
+        const value = asset.geography ?? asset.geographicRegion ?? position.geography ?? position.geographicRegion
+        if (known(value)) return {key: slug(value), label: text(value), rawKey: value, isUnknown: false}
+    }
+
+    if (groupBy === 'currency') {
+        const value = asset.currency ?? position.nativeCurrency ?? position.quoteCurrency ?? position.valuationCurrency ?? position.currency
+        if (known(value)) {
+            const normalized = currency(value)
+            return {key: normalized, label: normalized, rawKey: normalized, isUnknown: false}
+        }
+    }
+
+    return {key: UNKNOWN_KEY, label: UNKNOWN_LABEL, rawKey: null, isUnknown: true}
+}
+
+function resolveCompletionStatus(group, totalPositions) {
+    if (group.valuedPositionsCount === 0) return 'missing'
+    if (group.missingValuePositionsCount > 0 || group.unknownCategoryPositionsCount > 0) return 'partial'
+    if (group.positionsCount < totalPositions && groupByIsCategorical(group.groupBy)) return 'complete'
+    return 'complete'
+}
+
+function groupByIsCategorical(groupBy) {
+    return ['assetClass', 'sector', 'geography'].includes(groupBy)
+}
+
+function createEmptyGroup(groupBy, identity) {
+    return {
+        groupBy,
+        key: identity.key,
+        label: identity.label,
+        rawKey: identity.rawKey,
+        marketValue: 0,
+        value: 0,
+        allocationPercent: 0,
+        positionsCount: 0,
+        valuedPositionsCount: 0,
+        missingValuePositionsCount: 0,
+        unknownCategoryPositionsCount: 0,
+        completenessStatus: 'missing',
+        positionIds: [],
+    }
+}
+
+function calculateAllocationGroups(positions = [], groupBy, options = {}) {
+    if (!GROUPING_KEYS.includes(groupBy)) {
+        throw new Error(`Unsupported portfolio allocation grouping: ${groupBy}`)
+    }
+
+    const valuedTotal = options.totalMarketValue == null
+        ? positions.reduce((sum, position) => sum + positionValue(position), 0)
+        : Number(options.totalMarketValue)
+    const groups = new Map()
+
+    for (const position of positions) {
+        const identity = createGroupIdentity(position, groupBy)
+        const mapKey = identity.key
+        const group = groups.get(mapKey) || createEmptyGroup(groupBy, identity)
+        const value = positionValue(position)
+
+        group.marketValue = roundMoney(group.marketValue + value)
+        group.value = group.marketValue
+        group.positionsCount += 1
+        if (hasMarketValue(position)) group.valuedPositionsCount += 1
+        else group.missingValuePositionsCount += 1
+        if (identity.isUnknown) group.unknownCategoryPositionsCount += 1
+        group.positionIds.push(position.id)
+        groups.set(mapKey, group)
+    }
+
+    return [...groups.values()]
+        .map((group) => ({
+            ...group,
+            allocationPercent: valuedTotal > 0 ? roundMoney((group.marketValue / valuedTotal) * 100, 4) : 0,
+            completenessStatus: resolveCompletionStatus(group, positions.length),
+        }))
+        .sort((left, right) => right.marketValue - left.marketValue || left.label.localeCompare(right.label))
+}
+
+function calculateAllAllocationGroups(positions = [], options = {}) {
+    const valuedTotal = options.totalMarketValue == null
+        ? roundMoney(positions.reduce((sum, position) => sum + positionValue(position), 0))
+        : roundMoney(options.totalMarketValue)
+    const byGroup = {}
+
+    for (const groupBy of GROUPING_KEYS) {
+        byGroup[groupBy] = calculateAllocationGroups(positions, groupBy, {...options, totalMarketValue: valuedTotal})
+    }
+
+    return {
+        totalAllocatedValue: valuedTotal,
+        totalValuedPositions: positions.filter(hasMarketValue).length,
+        totalMissingValuePositions: positions.filter((position) => !hasMarketValue(position)).length,
+        byGroup,
+        flat: GROUPING_KEYS.flatMap((groupBy) => byGroup[groupBy]),
+    }
+}
+
+async function resolvePortfolioInput(input = {}, dependencies = {}) {
+    if (input.allocatablePositions) {
+        return {
+            baseCurrency: currency(input.baseCurrency ?? input.currency ?? dependencies.baseCurrency),
+            asOf: input.asOf || dependencies.asOf || dependencies.now?.() || new Date(),
+            positions: input.allocatablePositions,
+            totals: input.totals || {},
+            warnings: input.warnings || [],
+        }
+    }
+
+    if (input.metrics) return input.metrics
+    if (input.valuation) return input.valuation
+
+    return calculatePortfolioMetrics(input, dependencies)
+}
+
+async function calculatePortfolioAllocations(input = {}, dependencies = {}) {
+    const portfolio = await resolvePortfolioInput(input, dependencies)
+    const positions = Array.isArray(portfolio.positions) ? portfolio.positions : []
+    const totalMarketValue = portfolio.totals?.totalMarketValue == null
+        ? positions.reduce((sum, position) => sum + positionValue(position), 0)
+        : Number(portfolio.totals.totalMarketValue)
+    const allocations = calculateAllAllocationGroups(positions, {totalMarketValue})
+
+    return {
+        ...portfolio,
+        allocations,
+        allocationGroups: allocations.byGroup,
+        totals: {
+            ...(portfolio.totals || {}),
+            totalAllocatedValue: allocations.totalAllocatedValue,
+            totalValuedPositions: allocations.totalValuedPositions,
+            totalMissingValuePositions: allocations.totalMissingValuePositions,
+        },
+    }
+}
+
+function createPortfolioAllocationService(dependencies = {}) {
+    return {
+        calculatePortfolioAllocations: (input = {}) => calculatePortfolioAllocations(input, dependencies),
+        calculateAllocationGroups,
+        calculateAllAllocationGroups,
+    }
+}
+
+module.exports = {
+    GROUPING_KEYS,
+    UNKNOWN_KEY,
+    UNKNOWN_LABEL,
+    calculateAllocationGroups,
+    calculateAllAllocationGroups,
+    calculatePortfolioAllocations,
+    createPortfolioAllocationService,
+}

--- a/src/test/electron/portfolioAllocationService.test.js
+++ b/src/test/electron/portfolioAllocationService.test.js
@@ -1,0 +1,246 @@
+const {describe, expect, it} = require('vitest')
+const {
+    GROUPING_KEYS,
+    calculateAllocationGroups,
+    calculatePortfolioAllocations,
+} = require('../../../electron/portfolio/portfolioAllocationService')
+
+const positions = [
+    {
+        id: 1,
+        accountId: 10,
+        accountName: 'Brokerage CAD',
+        assetId: 100,
+        marketValue: 600,
+        currency: 'CAD',
+        valuationCurrency: 'CAD',
+        asset: {
+            id: 100,
+            symbol: 'XEQT',
+            name: 'XEQT ETF',
+            assetClass: 'ETF',
+            sector: 'Diversified',
+            geography: 'Global',
+            currency: 'CAD',
+        },
+    },
+    {
+        id: 2,
+        accountId: 10,
+        accountName: 'Brokerage CAD',
+        assetId: 101,
+        marketValue: 300,
+        currency: 'CAD',
+        valuationCurrency: 'CAD',
+        asset: {
+            id: 101,
+            symbol: 'AAPL',
+            name: 'Apple Inc.',
+            assetClass: 'EQUITY',
+            sector: 'Technology',
+            geography: 'United States',
+            currency: 'USD',
+        },
+    },
+    {
+        id: 3,
+        accountId: 11,
+        accountName: 'Crypto account',
+        assetId: 102,
+        marketValue: 100,
+        currency: 'CAD',
+        valuationCurrency: 'CAD',
+        asset: {
+            id: 102,
+            symbol: 'BTC',
+            name: 'Bitcoin',
+            assetClass: 'CRYPTO',
+            sector: null,
+            geography: null,
+            currency: 'USD',
+        },
+    },
+    {
+        id: 4,
+        accountId: 12,
+        accountName: 'Private assets',
+        assetId: 103,
+        marketValue: null,
+        currency: 'CAD',
+        valuationCurrency: 'CAD',
+        asset: {
+            id: 103,
+            symbol: 'PRIVATE',
+            name: 'Private placement',
+            assetClass: null,
+            sector: null,
+            geography: null,
+            currency: 'CAD',
+        },
+    },
+]
+
+describe('portfolio allocation service', () => {
+    it('calculates stable allocation groups for all supported dimensions', async () => {
+        const result = await calculatePortfolioAllocations({
+            allocatablePositions: positions,
+            baseCurrency: 'CAD',
+            totals: {totalMarketValue: 1000},
+        })
+
+        expect(Object.keys(result.allocationGroups)).toEqual(GROUPING_KEYS)
+        expect(result.allocations.totalAllocatedValue).toBe(1000)
+        expect(result.totals).toMatchObject({
+            totalAllocatedValue: 1000,
+            totalValuedPositions: 3,
+            totalMissingValuePositions: 1,
+        })
+    })
+
+    it('makes asset allocations add up to 100 percent for valued assets only', () => {
+        const assetGroups = calculateAllocationGroups(positions, 'asset')
+        const totalPercent = assetGroups.reduce((sum, group) => sum + group.allocationPercent, 0)
+
+        expect(totalPercent).toBe(100)
+        expect(assetGroups.map((group) => [group.label, group.marketValue, group.allocationPercent])).toEqual([
+            ['XEQT ETF', 600, 60],
+            ['Apple Inc.', 300, 30],
+            ['Bitcoin', 100, 10],
+            ['Private placement', 0, 0],
+        ])
+    })
+
+    it('groups by account, class and currency with position counts', async () => {
+        const result = await calculatePortfolioAllocations({
+            allocatablePositions: positions,
+            baseCurrency: 'CAD',
+        })
+
+        expect(result.allocationGroups.account.map((group) => ({
+            key: group.key,
+            label: group.label,
+            marketValue: group.marketValue,
+            allocationPercent: group.allocationPercent,
+            positionsCount: group.positionsCount,
+        }))).toEqual([
+            {key: '10', label: 'Brokerage CAD', marketValue: 900, allocationPercent: 90, positionsCount: 2},
+            {key: '11', label: 'Crypto account', marketValue: 100, allocationPercent: 10, positionsCount: 1},
+            {key: '12', label: 'Private assets', marketValue: 0, allocationPercent: 0, positionsCount: 1},
+        ])
+
+        expect(result.allocationGroups.assetClass.map((group) => [group.key, group.marketValue, group.positionsCount])).toEqual([
+            ['etf', 600, 1],
+            ['equity', 300, 1],
+            ['crypto', 100, 1],
+            ['unknown', 0, 1],
+        ])
+
+        expect(result.allocationGroups.currency.map((group) => [group.key, group.marketValue, group.allocationPercent, group.positionsCount])).toEqual([
+            ['CAD', 600, 60, 2],
+            ['USD', 400, 40, 2],
+        ])
+    })
+
+    it('keeps uncategorized assets visible in an unknown bucket', () => {
+        const sectorGroups = calculateAllocationGroups(positions, 'sector')
+        const geographyGroups = calculateAllocationGroups(positions, 'geography')
+
+        expect(sectorGroups).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                key: 'unknown',
+                label: 'Non classé',
+                marketValue: 100,
+                allocationPercent: 10,
+                positionsCount: 2,
+                unknownCategoryPositionsCount: 2,
+                completenessStatus: 'partial',
+            }),
+        ]))
+        expect(geographyGroups).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                key: 'unknown',
+                marketValue: 100,
+                allocationPercent: 10,
+                positionsCount: 2,
+                completenessStatus: 'partial',
+            }),
+        ]))
+    })
+
+    it('marks groups with missing prices as partial or missing without breaking allocations', () => {
+        const classGroups = calculateAllocationGroups(positions, 'assetClass')
+        const unknown = classGroups.find((group) => group.key === 'unknown')
+
+        expect(unknown).toMatchObject({
+            marketValue: 0,
+            allocationPercent: 0,
+            positionsCount: 1,
+            valuedPositionsCount: 0,
+            missingValuePositionsCount: 1,
+            completenessStatus: 'missing',
+        })
+    })
+
+    it('can calculate allocations from raw portfolio inputs through metrics service', async () => {
+        const result = await calculatePortfolioAllocations({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions: [
+                {
+                    id: 1,
+                    accountId: 10,
+                    accountName: 'Brokerage',
+                    instrumentId: 100,
+                    marketInstrumentId: 500,
+                    currency: 'USD',
+                    instrument: {
+                        id: 100,
+                        symbol: 'AAPL',
+                        name: 'Apple Inc.',
+                        assetClass: 'EQUITY',
+                        sector: 'Technology',
+                        geographicRegion: 'United States',
+                        currency: 'USD',
+                        marketInstrumentId: 500,
+                    },
+                },
+                {
+                    id: 2,
+                    accountId: 10,
+                    accountName: 'Brokerage',
+                    instrumentId: 101,
+                    marketInstrumentId: null,
+                    currency: 'CAD',
+                    costBasis: 200,
+                    instrument: {
+                        id: 101,
+                        symbol: 'PRIVATE',
+                        name: 'Private asset',
+                        assetClass: null,
+                        sector: null,
+                        geographicRegion: null,
+                        currency: 'CAD',
+                        marketInstrumentId: null,
+                    },
+                },
+            ],
+            movements: [
+                {id: 1, type: 'BUY', positionId: 1, quantity: 2, unitPrice: 100, priceCurrency: 'USD', feeAmount: 0, operationDate: '2026-04-01'},
+            ],
+            priceSnapshots: [
+                {id: 1, marketInstrumentId: 500, unitPrice: 150, currency: 'USD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+            ],
+            fxRates: {'USD:CAD': 1.25},
+        })
+
+        expect(result.totals.totalMarketValue).toBe(375)
+        expect(result.allocationGroups.asset).toEqual(expect.arrayContaining([
+            expect.objectContaining({label: 'Apple Inc.', marketValue: 375, allocationPercent: 100}),
+            expect.objectContaining({label: 'Private asset', marketValue: 0, allocationPercent: 0, completenessStatus: 'missing'}),
+        ]))
+        expect(result.allocationGroups.currency).toEqual(expect.arrayContaining([
+            expect.objectContaining({key: 'USD', marketValue: 375, allocationPercent: 100}),
+            expect.objectContaining({key: 'CAD', marketValue: 0, allocationPercent: 0}),
+        ]))
+    })
+})


### PR DESCRIPTION
## Summary

Closes #45.

- Add a pure portfolio allocation service for dashboard-ready allocation groups.
- Calculate allocations by asset, account, asset class, sector, geography and currency.
- Include total value, allocation percentage, position count and completeness status per group.
- Keep uncategorized assets visible in a `Non classé` / `unknown` bucket.
- Keep positions with missing prices visible without letting them break allocation totals.
- Allow allocations to be computed from already-valued positions or from raw portfolio inputs through the metrics service.
- Add unit tests for all groupings, 100% valued allocation totals, unknown buckets, missing prices and multi-currency cases.

## Validation

- Added Vitest unit coverage for the allocation service.
- I could not run the repository's full `npm run check` locally because the sandbox does not have the repo dependencies installed. CI should be treated as source of truth.

Base branch: `epic4`.