### PR TITLE
Add portfolio history snapshots

### DIFF
--- a/electron/portfolio/portfolioHistoryService.js
+++ b/electron/portfolio/portfolioHistoryService.js
@@ -1,0 +1,361 @@
+const {calculatePortfolioMetrics} = require('./portfolioMetricsService')
+const {calculatePortfolioIncome} = require('./portfolioIncomeService')
+const {roundMoney} = require('./portfolioValuationService')
+
+const SNAPSHOT_SOURCES = new Set(['MANUAL', 'GENERATED', 'IMPORTED'])
+const COMPLETENESS_STATUSES = new Set(['COMPLETE', 'PARTIAL', 'MISSING', 'UNKNOWN'])
+
+const text = (value) => typeof value === 'string' && value.trim() ? value.trim() : null
+const numberOr = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback
+const maybeNumber = (value) => value == null || value === '' || !Number.isFinite(Number(value)) ? null : Number(value)
+const currency = (value, fallback = 'CAD') => (text(value) || fallback).toUpperCase()
+
+function normalizeDate(value, fallback = new Date()) {
+    const parsed = value instanceof Date ? new Date(value.getTime()) : new Date(value == null || value === '' ? fallback : value)
+    return Number.isNaN(parsed.getTime()) ? fallback : parsed
+}
+
+function startOfUtcDay(value) {
+    const date = normalizeDate(value)
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+function serializeDate(value) {
+    return startOfUtcDay(value).toISOString().slice(0, 10)
+}
+
+function normalizeSource(value) {
+    const source = (text(value) || 'MANUAL').toUpperCase()
+    return SNAPSHOT_SOURCES.has(source) ? source : 'MANUAL'
+}
+
+function normalizeCompletenessStatus(value) {
+    const status = (text(value) || 'UNKNOWN').toUpperCase()
+    return COMPLETENESS_STATUSES.has(status) ? status : 'UNKNOWN'
+}
+
+function normalizePeriod(input = {}) {
+    const snapshotDate = startOfUtcDay(input.snapshotDate || input.date || input.asOf || new Date())
+    return {
+        snapshotDate,
+        periodKey: input.periodKey || serializeDate(snapshotDate),
+    }
+}
+
+function createSnapshotKey({portfolioId = null, periodKey, currency: snapshotCurrency, source}) {
+    return [portfolioId == null ? 'global' : String(portfolioId), periodKey, currency(snapshotCurrency), normalizeSource(source)].join(':')
+}
+
+function getValuedPositionsCount(portfolioState = {}) {
+    if (portfolioState.totals?.totalValuedPositions != null) return numberOr(portfolioState.totals.totalValuedPositions)
+    return (portfolioState.positions || []).filter((position) => position.marketValue != null).length
+}
+
+function getMissingValuePositionsCount(portfolioState = {}) {
+    if (portfolioState.totals?.totalMissingValuePositions != null) return numberOr(portfolioState.totals.totalMissingValuePositions)
+    return (portfolioState.positions || []).filter((position) => position.marketValue == null).length
+}
+
+function resolveCompletenessStatus(portfolioState = {}, explicitStatus = null) {
+    if (explicitStatus) return normalizeCompletenessStatus(explicitStatus)
+    const positionsCount = Array.isArray(portfolioState.positions) ? portfolioState.positions.length : numberOr(portfolioState.totals?.positionsCount)
+    const valuedPositionsCount = getValuedPositionsCount(portfolioState)
+    const missingValuePositionsCount = getMissingValuePositionsCount(portfolioState)
+
+    if (positionsCount === 0 || valuedPositionsCount === 0) return 'MISSING'
+    if (missingValuePositionsCount > 0) return 'PARTIAL'
+    return 'COMPLETE'
+}
+
+function safeJson(value) {
+    try {
+        return JSON.stringify(value || null)
+    } catch (_) {
+        return null
+    }
+}
+
+function parseJson(value) {
+    if (!value || typeof value !== 'string') return null
+    try {
+        return JSON.parse(value)
+    } catch (_) {
+        return null
+    }
+}
+
+function buildSnapshotPayload(portfolioState, incomeState, input = {}) {
+    const positions = Array.isArray(portfolioState.positions) ? portfolioState.positions : []
+    return {
+        totals: portfolioState.totals || {},
+        gainMetrics: portfolioState.gainMetrics || null,
+        incomeSummary: incomeState?.summary || null,
+        positions: positions.map((position) => ({
+            id: position.id,
+            assetId: position.assetId,
+            accountId: position.accountId,
+            marketValue: position.marketValue,
+            investedCost: position.investedCost,
+            valuationStatus: position.valuationStatus,
+            completenessStatus: position.marketValue == null ? 'MISSING' : 'COMPLETE',
+        })),
+        warnings: [...(portfolioState.warnings || []), ...(incomeState?.warnings || [])],
+        metadata: input.metadata || null,
+    }
+}
+
+function buildPortfolioSnapshot(input = {}, portfolioState = {}, incomeState = null) {
+    const {snapshotDate, periodKey} = normalizePeriod(input)
+    const source = normalizeSource(input.source)
+    const snapshotCurrency = currency(input.currency || input.baseCurrency || portfolioState.baseCurrency || portfolioState.totals?.currency)
+    const positionsCount = Array.isArray(portfolioState.positions) ? portfolioState.positions.length : numberOr(portfolioState.totals?.positionsCount)
+    const valuedPositionsCount = getValuedPositionsCount(portfolioState)
+    const missingValuePositionsCount = getMissingValuePositionsCount(portfolioState)
+    const completenessStatus = resolveCompletenessStatus(portfolioState, input.completenessStatus)
+    const totalMarketValue = roundMoney(portfolioState.totals?.totalMarketValue ?? input.totalMarketValue)
+    const totalInvestedCost = roundMoney(portfolioState.totals?.totalInvestedCost ?? input.totalInvestedCost)
+    const totalUnrealizedGain = roundMoney(
+        portfolioState.totals?.totalUnrealizedGain ??
+        portfolioState.gainMetrics?.totalUnrealizedGain ??
+        input.totalUnrealizedGain,
+    )
+    const cumulativeIncome = incomeState?.summary?.totalIncome ?? input.cumulativeIncome ?? null
+    const cumulativeFees = incomeState?.summary?.totalFees ?? input.cumulativeFees ?? null
+    const portfolioId = maybeNumber(input.portfolioId ?? portfolioState.portfolioId)
+
+    return {
+        id: maybeNumber(input.id),
+        snapshotKey: createSnapshotKey({portfolioId, periodKey, currency: snapshotCurrency, source}),
+        portfolioId,
+        snapshotDate,
+        periodKey,
+        source,
+        currency: snapshotCurrency,
+        totalMarketValue,
+        totalInvestedCost,
+        totalUnrealizedGain,
+        cumulativeIncome: cumulativeIncome == null ? null : roundMoney(cumulativeIncome),
+        cumulativeFees: cumulativeFees == null ? null : roundMoney(cumulativeFees),
+        completenessStatus,
+        positionsCount,
+        valuedPositionsCount,
+        missingValuePositionsCount,
+        payloadJson: safeJson(buildSnapshotPayload(portfolioState, incomeState, input)),
+        note: input.note || null,
+        createdAt: input.createdAt ? normalizeDate(input.createdAt) : undefined,
+        updatedAt: input.updatedAt ? normalizeDate(input.updatedAt) : undefined,
+    }
+}
+
+function deserializeSnapshot(snapshot) {
+    if (!snapshot) return null
+    return {
+        ...snapshot,
+        snapshotDate: normalizeDate(snapshot.snapshotDate),
+        createdAt: snapshot.createdAt ? normalizeDate(snapshot.createdAt) : snapshot.createdAt,
+        updatedAt: snapshot.updatedAt ? normalizeDate(snapshot.updatedAt) : snapshot.updatedAt,
+        payload: parseJson(snapshot.payloadJson),
+    }
+}
+
+function matchesPeriod(snapshot, filter = {}) {
+    const value = normalizeDate(snapshot.snapshotDate).getTime()
+    const start = filter.startDate ? startOfUtcDay(filter.startDate).getTime() : Number.NEGATIVE_INFINITY
+    const end = filter.endDate ? startOfUtcDay(filter.endDate).getTime() : Number.POSITIVE_INFINITY
+    return value >= start && value < end
+}
+
+function matchesSnapshotFilter(snapshot, filter = {}) {
+    if (filter.portfolioId !== undefined && maybeNumber(snapshot.portfolioId) !== maybeNumber(filter.portfolioId)) return false
+    if (filter.currency && currency(snapshot.currency) !== currency(filter.currency)) return false
+    if (filter.source && normalizeSource(snapshot.source) !== normalizeSource(filter.source)) return false
+    return matchesPeriod(snapshot, filter)
+}
+
+function createMemoryPortfolioSnapshotRepository(initialSnapshots = []) {
+    let nextId = 1
+    const snapshots = initialSnapshots.map((snapshot) => {
+        const normalized = deserializeSnapshot(snapshot)
+        const id = normalized.id || nextId++
+        nextId = Math.max(nextId, id + 1)
+        return {...normalized, id}
+    })
+
+    return {
+        async findDuplicate(snapshot) {
+            return snapshots.find((item) => item.snapshotKey === snapshot.snapshotKey) || null
+        },
+        async createSnapshot(snapshot) {
+            const now = new Date()
+            const stored = deserializeSnapshot({
+                ...snapshot,
+                id: snapshot.id || nextId++,
+                createdAt: snapshot.createdAt || now,
+                updatedAt: snapshot.updatedAt || now,
+            })
+            snapshots.push(stored)
+            return stored
+        },
+        async updateSnapshot(id, snapshot) {
+            const index = snapshots.findIndex((item) => item.id === id)
+            if (index === -1) return null
+            snapshots[index] = deserializeSnapshot({...snapshots[index], ...snapshot, id, updatedAt: new Date()})
+            return snapshots[index]
+        },
+        async listSnapshots(filter = {}) {
+            return snapshots
+                .filter((snapshot) => matchesSnapshotFilter(snapshot, filter))
+                .sort((left, right) => normalizeDate(left.snapshotDate) - normalizeDate(right.snapshotDate) || left.id - right.id)
+                .map(deserializeSnapshot)
+        },
+        async getLatestSnapshot(filter = {}) {
+            const items = await this.listSnapshots(filter)
+            return items[items.length - 1] || null
+        },
+        _all() {
+            return snapshots.map(deserializeSnapshot)
+        },
+    }
+}
+
+function createPrismaPortfolioSnapshotRepository(prisma) {
+    if (!prisma?.portfolioSnapshot) {
+        throw new Error('Prisma client does not expose portfolioSnapshot. Run the Prisma migration/generation first.')
+    }
+
+    return {
+        findDuplicate(snapshot) {
+            return prisma.portfolioSnapshot.findUnique({where: {snapshotKey: snapshot.snapshotKey}})
+        },
+        createSnapshot(snapshot) {
+            return prisma.portfolioSnapshot.create({data: snapshot})
+        },
+        updateSnapshot(id, snapshot) {
+            return prisma.portfolioSnapshot.update({where: {id}, data: snapshot})
+        },
+        listSnapshots(filter = {}) {
+            const where = {}
+            if (filter.portfolioId !== undefined) where.portfolioId = maybeNumber(filter.portfolioId)
+            if (filter.currency) where.currency = currency(filter.currency)
+            if (filter.source) where.source = normalizeSource(filter.source)
+            if (filter.startDate || filter.endDate) {
+                where.snapshotDate = {}
+                if (filter.startDate) where.snapshotDate.gte = startOfUtcDay(filter.startDate)
+                if (filter.endDate) where.snapshotDate.lt = startOfUtcDay(filter.endDate)
+            }
+            return prisma.portfolioSnapshot.findMany({where, orderBy: [{snapshotDate: 'asc'}, {id: 'asc'}]})
+        },
+        async getLatestSnapshot(filter = {}) {
+            const where = {}
+            if (filter.portfolioId !== undefined) where.portfolioId = maybeNumber(filter.portfolioId)
+            if (filter.currency) where.currency = currency(filter.currency)
+            if (filter.source) where.source = normalizeSource(filter.source)
+            return prisma.portfolioSnapshot.findFirst({where, orderBy: [{snapshotDate: 'desc'}, {id: 'desc'}]})
+        },
+    }
+}
+
+function resolveRepository(dependencies = {}) {
+    if (dependencies.repository) return dependencies.repository
+    if (dependencies.prisma) return createPrismaPortfolioSnapshotRepository(dependencies.prisma)
+    return createMemoryPortfolioSnapshotRepository()
+}
+
+async function resolvePortfolioState(input = {}, dependencies = {}) {
+    if (input.portfolioState) return input.portfolioState
+    if (input.metrics) return input.metrics
+    return calculatePortfolioMetrics(input, dependencies)
+}
+
+async function resolveIncomeState(input = {}, dependencies = {}) {
+    if (input.incomeState) return input.incomeState
+    if (input.income) return input.income
+    if (input.includeIncome || input.incomeMovements) {
+        return calculatePortfolioIncome({
+            ...input,
+            movements: input.incomeMovements || input.movements || [],
+            startDate: input.incomeStartDate || input.startDate,
+            endDate: input.incomeEndDate || input.endDate,
+        }, dependencies)
+    }
+    return null
+}
+
+async function createPortfolioSnapshot(input = {}, dependencies = {}) {
+    const repository = resolveRepository(dependencies)
+    const portfolioState = await resolvePortfolioState(input, dependencies)
+    const incomeState = await resolveIncomeState(input, dependencies)
+    const snapshot = buildPortfolioSnapshot(input, portfolioState, incomeState)
+    const existing = await repository.findDuplicate(snapshot)
+
+    if (existing && !input.replaceDuplicate) {
+        return {
+            snapshot: deserializeSnapshot(existing),
+            created: false,
+            duplicate: true,
+            replaced: false,
+        }
+    }
+
+    if (existing && input.replaceDuplicate) {
+        const updated = await repository.updateSnapshot(existing.id, snapshot)
+        return {
+            snapshot: deserializeSnapshot(updated),
+            created: false,
+            duplicate: true,
+            replaced: true,
+        }
+    }
+
+    const created = await repository.createSnapshot(snapshot)
+    return {
+        snapshot: deserializeSnapshot(created),
+        created: true,
+        duplicate: false,
+        replaced: false,
+    }
+}
+
+async function readPortfolioSnapshotHistory(input = {}, dependencies = {}) {
+    const repository = resolveRepository(dependencies)
+    const snapshots = await repository.listSnapshots({
+        portfolioId: input.portfolioId,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        currency: input.currency || input.baseCurrency,
+        source: input.source,
+    })
+    return {
+        portfolioId: input.portfolioId ?? null,
+        currency: input.currency || input.baseCurrency || null,
+        startDate: input.startDate || null,
+        endDate: input.endDate || null,
+        snapshots: snapshots.map(deserializeSnapshot),
+    }
+}
+
+async function generateAutomaticPortfolioSnapshotIfNeeded(input = {}, dependencies = {}) {
+    return createPortfolioSnapshot({...input, source: 'GENERATED'}, dependencies)
+}
+
+function createPortfolioHistoryService(dependencies = {}) {
+    const repository = resolveRepository(dependencies)
+    return {
+        repository,
+        createPortfolioSnapshot: (input = {}) => createPortfolioSnapshot(input, {...dependencies, repository}),
+        generateAutomaticPortfolioSnapshotIfNeeded: (input = {}) =>
+            generateAutomaticPortfolioSnapshotIfNeeded(input, {...dependencies, repository}),
+        readPortfolioSnapshotHistory: (input = {}) => readPortfolioSnapshotHistory(input, {...dependencies, repository}),
+    }
+}
+
+module.exports = {
+    buildPortfolioSnapshot,
+    createMemoryPortfolioSnapshotRepository,
+    createPortfolioHistoryService,
+    createPortfolioSnapshot,
+    createPrismaPortfolioSnapshotRepository,
+    generateAutomaticPortfolioSnapshotIfNeeded,
+    readPortfolioSnapshotHistory,
+    serializeDate,
+}

--- a/prisma/migrations/20260430191500_add_portfolio_snapshots/migration.sql
+++ b/prisma/migrations/20260430191500_add_portfolio_snapshots/migration.sql
@@ -1,0 +1,34 @@
+-- Local portfolio history snapshots for Epic 4.
+-- This table stores dashboard-ready aggregates so history can be read offline
+-- without rebuilding valuations or calling market-data providers.
+
+CREATE TABLE "PortfolioSnapshot" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "snapshotKey" TEXT NOT NULL,
+    "portfolioId" INTEGER,
+    "snapshotDate" DATETIME NOT NULL,
+    "periodKey" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'MANUAL',
+    "currency" TEXT NOT NULL DEFAULT 'CAD',
+    "totalMarketValue" REAL NOT NULL DEFAULT 0,
+    "totalInvestedCost" REAL NOT NULL DEFAULT 0,
+    "totalUnrealizedGain" REAL NOT NULL DEFAULT 0,
+    "cumulativeIncome" REAL,
+    "cumulativeFees" REAL,
+    "completenessStatus" TEXT NOT NULL DEFAULT 'UNKNOWN',
+    "positionsCount" INTEGER NOT NULL DEFAULT 0,
+    "valuedPositionsCount" INTEGER NOT NULL DEFAULT 0,
+    "missingValuePositionsCount" INTEGER NOT NULL DEFAULT 0,
+    "payloadJson" TEXT,
+    "note" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PortfolioSnapshot_portfolioId_fkey" FOREIGN KEY ("portfolioId") REFERENCES "Portfolio" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "PortfolioSnapshot_snapshotKey_key" ON "PortfolioSnapshot"("snapshotKey");
+CREATE INDEX "PortfolioSnapshot_portfolioId_idx" ON "PortfolioSnapshot"("portfolioId");
+CREATE INDEX "PortfolioSnapshot_snapshotDate_idx" ON "PortfolioSnapshot"("snapshotDate");
+CREATE INDEX "PortfolioSnapshot_currency_idx" ON "PortfolioSnapshot"("currency");
+CREATE INDEX "PortfolioSnapshot_source_idx" ON "PortfolioSnapshot"("source");
+CREATE INDEX "PortfolioSnapshot_completenessStatus_idx" ON "PortfolioSnapshot"("completenessStatus");

--- a/src/test/electron/portfolioHistoryService.test.js
+++ b/src/test/electron/portfolioHistoryService.test.js
@@ -1,0 +1,208 @@
+const {describe, expect, it} = require('vitest')
+const {
+    buildPortfolioSnapshot,
+    createMemoryPortfolioSnapshotRepository,
+    createPortfolioHistoryService,
+    createPortfolioSnapshot,
+    generateAutomaticPortfolioSnapshotIfNeeded,
+    readPortfolioSnapshotHistory,
+} = require('../../../electron/portfolio/portfolioHistoryService')
+
+function portfolioState(overrides = {}) {
+    return {
+        baseCurrency: 'CAD',
+        totals: {
+            totalMarketValue: 1500,
+            totalInvestedCost: 1200,
+            totalUnrealizedGain: 300,
+            totalValuedPositions: 1,
+            totalMissingValuePositions: 0,
+            positionsCount: 1,
+            ...overrides.totals,
+        },
+        gainMetrics: {
+            totalUnrealizedGain: 300,
+        },
+        positions: [
+            {
+                id: 1,
+                assetId: 100,
+                accountId: 10,
+                marketValue: 1500,
+                investedCost: 1200,
+                valuationStatus: 'market',
+            },
+        ],
+        warnings: [],
+        ...overrides,
+    }
+}
+
+function incomeState(overrides = {}) {
+    return {
+        summary: {
+            totalIncome: 42,
+            totalFees: 5,
+            netIncome: 37,
+            ...overrides.summary,
+        },
+        warnings: [],
+        ...overrides,
+    }
+}
+
+describe('portfolio history service', () => {
+    it('builds a local snapshot payload from portfolio metrics and income aggregates', () => {
+        const snapshot = buildPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', note: 'Month end'},
+            portfolioState(),
+            incomeState(),
+        )
+
+        expect(snapshot).toMatchObject({
+            snapshotKey: '7:2026-04-30:CAD:MANUAL',
+            portfolioId: 7,
+            periodKey: '2026-04-30',
+            source: 'MANUAL',
+            currency: 'CAD',
+            totalMarketValue: 1500,
+            totalInvestedCost: 1200,
+            totalUnrealizedGain: 300,
+            cumulativeIncome: 42,
+            cumulativeFees: 5,
+            completenessStatus: 'COMPLETE',
+            positionsCount: 1,
+            valuedPositionsCount: 1,
+            missingValuePositionsCount: 0,
+            note: 'Month end',
+        })
+        expect(JSON.parse(snapshot.payloadJson)).toMatchObject({
+            incomeSummary: {totalIncome: 42, totalFees: 5, netIncome: 37},
+            positions: [expect.objectContaining({id: 1, marketValue: 1500})],
+        })
+    })
+
+    it('creates a manual snapshot and reads history by period without external providers', async () => {
+        const repository = createMemoryPortfolioSnapshotRepository()
+        const created = await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-15', source: 'MANUAL', portfolioState: portfolioState()},
+            {repository},
+        )
+        await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-05-01', source: 'MANUAL', portfolioState: portfolioState({totals: {totalMarketValue: 1600}})},
+            {repository},
+        )
+
+        const history = await readPortfolioSnapshotHistory(
+            {portfolioId: 7, startDate: '2026-04-01', endDate: '2026-05-01', currency: 'CAD'},
+            {repository},
+        )
+
+        expect(created).toMatchObject({created: true, duplicate: false})
+        expect(history.snapshots).toHaveLength(1)
+        expect(history.snapshots[0]).toMatchObject({
+            portfolioId: 7,
+            totalMarketValue: 1500,
+            snapshotKey: '7:2026-04-15:CAD:MANUAL',
+        })
+    })
+
+    it('avoids obvious duplicates for the same portfolio, date, currency and source', async () => {
+        const repository = createMemoryPortfolioSnapshotRepository()
+        const first = await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', portfolioState: portfolioState()},
+            {repository},
+        )
+        const duplicate = await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', portfolioState: portfolioState({totals: {totalMarketValue: 9999}})},
+            {repository},
+        )
+
+        expect(first.created).toBe(true)
+        expect(duplicate).toMatchObject({created: false, duplicate: true, replaced: false})
+        expect(duplicate.snapshot.totalMarketValue).toBe(1500)
+        expect(repository._all()).toHaveLength(1)
+    })
+
+    it('can replace a duplicate snapshot when explicitly requested', async () => {
+        const repository = createMemoryPortfolioSnapshotRepository()
+        await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', portfolioState: portfolioState()},
+            {repository},
+        )
+        const replacement = await createPortfolioSnapshot(
+            {
+                portfolioId: 7,
+                snapshotDate: '2026-04-30',
+                source: 'MANUAL',
+                replaceDuplicate: true,
+                portfolioState: portfolioState({totals: {totalMarketValue: 1750, totalInvestedCost: 1300, totalUnrealizedGain: 450}}),
+            },
+            {repository},
+        )
+
+        expect(replacement).toMatchObject({created: false, duplicate: true, replaced: true})
+        expect(replacement.snapshot).toMatchObject({
+            totalMarketValue: 1750,
+            totalInvestedCost: 1300,
+            totalUnrealizedGain: 450,
+        })
+        expect(repository._all()).toHaveLength(1)
+    })
+
+    it('keeps partial snapshots usable when some assets have missing values', async () => {
+        const repository = createMemoryPortfolioSnapshotRepository()
+        const partialState = portfolioState({
+            totals: {
+                totalMarketValue: 1500,
+                totalInvestedCost: 1800,
+                totalUnrealizedGain: 300,
+                totalValuedPositions: 1,
+                totalMissingValuePositions: 1,
+                positionsCount: 2,
+            },
+            positions: [
+                {id: 1, assetId: 100, accountId: 10, marketValue: 1500, investedCost: 1200, valuationStatus: 'market'},
+                {id: 2, assetId: 101, accountId: 10, marketValue: null, investedCost: 600, valuationStatus: 'missing'},
+            ],
+        })
+
+        const result = await createPortfolioSnapshot(
+            {portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', portfolioState: partialState},
+            {repository},
+        )
+
+        expect(result.snapshot).toMatchObject({
+            completenessStatus: 'PARTIAL',
+            positionsCount: 2,
+            valuedPositionsCount: 1,
+            missingValuePositionsCount: 1,
+        })
+        expect(result.snapshot.payload.positions).toEqual(expect.arrayContaining([
+            expect.objectContaining({id: 2, completenessStatus: 'MISSING'}),
+        ]))
+    })
+
+    it('generates automatic snapshots with a separate anti-duplicate key from manual snapshots', async () => {
+        const repository = createMemoryPortfolioSnapshotRepository()
+        const service = createPortfolioHistoryService({repository})
+        await service.createPortfolioSnapshot({portfolioId: 7, snapshotDate: '2026-04-30', source: 'MANUAL', portfolioState: portfolioState()})
+        const generated = await service.generateAutomaticPortfolioSnapshotIfNeeded({
+            portfolioId: 7,
+            snapshotDate: '2026-04-30',
+            portfolioState: portfolioState({totals: {totalMarketValue: 1600}}),
+        })
+        const duplicateGenerated = await generateAutomaticPortfolioSnapshotIfNeeded({
+            portfolioId: 7,
+            snapshotDate: '2026-04-30',
+            portfolioState: portfolioState({totals: {totalMarketValue: 1700}}),
+        }, {repository})
+
+        expect(generated).toMatchObject({created: true, duplicate: false})
+        expect(duplicateGenerated).toMatchObject({created: false, duplicate: true})
+        expect(repository._all().map((snapshot) => snapshot.snapshotKey).sort()).toEqual([
+            '7:2026-04-30:CAD:GENERATED',
+            '7:2026-04-30:CAD:MANUAL',
+        ])
+    })
+})


### PR DESCRIPTION
## Summary

Closes #47.

- Add a portfolio history service for local snapshots.
- Store snapshot aggregates: date, total value, invested cost, unrealized gain, optional cumulative income/fees, display currency and completeness status.
- Add manual snapshot creation and lightweight generated snapshot creation.
- Add history reads by period, currency, source and portfolio.
- Add anti-duplicate strategy using `portfolioId:periodKey:currency:source` snapshot keys.
- Keep partial snapshots usable when some positions have missing values.
- Add a SQLite migration for the local `PortfolioSnapshot` table.
- Add unit tests covering snapshot creation, period reads, anti-duplicate behavior, replacement and partial/missing-value snapshots.

## Validation

- Added Vitest unit coverage for the snapshot service using the in-memory repository adapter.
- I could not run the repository's full `npm run check` locally because the sandbox does not have the repo dependencies installed. CI should be treated as source of truth.

Base branch: `epic4`.