### PR TITLE
Build portfolio analytics dashboard MVP

### DIFF
--- a/electron/ipc/registerWealthHandlers.js
+++ b/electron/ipc/registerWealthHandlers.js
@@ -1,6 +1,7 @@
 const {ipcMain} = require('electron')
 
 const {getPrisma} = require('../db')
+const {getPortfolioDashboard} = require('../portfolio/portfolioDashboardService')
 const {
     createAsset,
     createLiability,
@@ -42,6 +43,9 @@ function registerWealthHandlers(prisma = getPrisma()) {
         createGeneratedNetWorthSnapshot(prisma, options),
     )
     ipcMain.handle('db:netWorthSnapshot:list', async (_event, filters) => listNetWorthSnapshots(prisma, filters))
+    ipcMain.handle('db:portfolioAnalytics:dashboard', async (_event, options) =>
+        getPortfolioDashboard(options || {}, {prisma}),
+    )
 }
 
 module.exports = {registerWealthHandlers}

--- a/electron/portfolio/portfolioDashboardService.js
+++ b/electron/portfolio/portfolioDashboardService.js
@@ -1,0 +1,217 @@
+const {calculatePortfolioAllocations} = require('./portfolioAllocationService')
+const {calculatePortfolioIncome} = require('./portfolioIncomeService')
+const {readPortfolioSnapshotHistory} = require('./portfolioHistoryService')
+const {roundMoney} = require('./portfolioValuationService')
+
+const text = (value) => typeof value === 'string' && value.trim() ? value.trim() : null
+const currency = (value, fallback = 'CAD') => (text(value) || fallback).toUpperCase()
+const maybeNumber = (value) => value == null || value === '' || !Number.isFinite(Number(value)) ? null : Number(value)
+
+function normalizeDate(value, fallback = new Date()) {
+    const parsed = value instanceof Date ? new Date(value.getTime()) : new Date(value == null || value === '' ? fallback : value)
+    return Number.isNaN(parsed.getTime()) ? fallback : parsed
+}
+
+function isoDate(value, fallback = new Date()) {
+    return normalizeDate(value, fallback).toISOString().slice(0, 10)
+}
+
+function monthsAgo(value, count) {
+    const date = normalizeDate(value)
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - count, date.getUTCDate()))
+}
+
+function startOfCurrentMonth(value) {
+    const date = normalizeDate(value)
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1))
+}
+
+function endExclusiveOfNextDay(value) {
+    const date = normalizeDate(value)
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1))
+}
+
+function serializeSnapshot(snapshot) {
+    return {
+        id: snapshot.id,
+        snapshotDate: isoDate(snapshot.snapshotDate),
+        totalMarketValue: roundMoney(snapshot.totalMarketValue),
+        totalInvestedCost: roundMoney(snapshot.totalInvestedCost),
+        totalUnrealizedGain: roundMoney(snapshot.totalUnrealizedGain),
+        cumulativeIncome: snapshot.cumulativeIncome == null ? null : roundMoney(snapshot.cumulativeIncome),
+        cumulativeFees: snapshot.cumulativeFees == null ? null : roundMoney(snapshot.cumulativeFees),
+        currency: currency(snapshot.currency),
+        completenessStatus: snapshot.completenessStatus || 'UNKNOWN',
+        source: snapshot.source || 'MANUAL',
+    }
+}
+
+function toHistorySeries(history = {}) {
+    return (history.snapshots || []).map(serializeSnapshot)
+}
+
+function summarizeDataStatus(positions = []) {
+    const empty = {fresh: 0, stale: 0, missing: 0, manual: 0, error: 0, total: positions.length}
+    for (const position of positions) {
+        const status = String(position.valuationStatus || position.freshnessStatus || 'missing').toLowerCase()
+        if (status === 'market' || status === 'fresh') empty.fresh += 1
+        else if (status === 'stale') empty.stale += 1
+        else if (status === 'manual') empty.manual += 1
+        else if (status === 'error') empty.error += 1
+        else empty.missing += 1
+    }
+    return empty
+}
+
+function getAllocationBlock(allocations, key) {
+    return allocations?.byGroup?.[key] || []
+}
+
+function buildPortfolioDashboardState({allocations, income, history, baseCurrency, asOf, portfolioId = null}) {
+    const positions = allocations.positions || []
+    const totals = allocations.totals || {}
+    const gainMetrics = allocations.gainMetrics || {}
+    const dataStatus = summarizeDataStatus(positions)
+    const historySeries = toHistorySeries(history)
+    const isEmpty = positions.length === 0
+    const hasNoPrice = !isEmpty && dataStatus.fresh + dataStatus.stale + dataStatus.manual === 0
+
+    return {
+        portfolioId,
+        baseCurrency,
+        asOf: normalizeDate(asOf).toISOString(),
+        isEmpty,
+        hasNoPrice,
+        hasHistory: historySeries.length > 0,
+        kpis: {
+            totalMarketValue: roundMoney(totals.totalMarketValue),
+            totalInvestedCost: roundMoney(totals.totalInvestedCost),
+            totalUnrealizedGain: roundMoney(totals.totalUnrealizedGain ?? gainMetrics.totalUnrealizedGain),
+            totalUnrealizedGainPercent: totals.totalUnrealizedGainPercent ?? gainMetrics.totalUnrealizedGainPercent ?? null,
+            periodIncome: roundMoney(income.summary?.totalIncome),
+            periodFees: roundMoney(income.summary?.totalFees),
+            netIncome: roundMoney(income.summary?.netIncome),
+            grossReturnSimple: totals.grossReturnSimple ?? gainMetrics.grossReturnSimple ?? null,
+        },
+        allocationBlocks: {
+            asset: getAllocationBlock(allocations.allocations, 'asset'),
+            assetClass: getAllocationBlock(allocations.allocations, 'assetClass'),
+            sector: getAllocationBlock(allocations.allocations, 'sector'),
+            geography: getAllocationBlock(allocations.allocations, 'geography'),
+            currency: getAllocationBlock(allocations.allocations, 'currency'),
+        },
+        dataStatus,
+        history: historySeries,
+        income,
+        warnings: [...(allocations.warnings || []), ...(income.summary?.unconvertedByCurrency || []).map((row) => ({
+            positionId: null,
+            warning: `${row.amount} ${row.currency} ${row.kind} non convertis`,
+        }))],
+        ctas: {
+            addAsset: 'Ajouter un actif',
+            addMovement: 'Saisir un mouvement',
+        },
+    }
+}
+
+async function loadPortfolioDashboardSource(prisma, options = {}) {
+    if (!prisma) {
+        return {
+            positions: options.positions || [],
+            movements: options.movements || [],
+            priceSnapshots: options.priceSnapshots || [],
+        }
+    }
+
+    const portfolioId = maybeNumber(options.portfolioId)
+    const positionWhere = portfolioId == null ? {} : {portfolioId}
+    const movementWhere = portfolioId == null ? {} : {portfolioId}
+
+    const [positions, movements] = await Promise.all([
+        prisma.investmentPosition.findMany({
+            where: positionWhere,
+            include: {
+                account: true,
+                portfolio: true,
+                instrument: {include: {marketInstrument: true}},
+            },
+            orderBy: [{status: 'asc'}, {id: 'asc'}],
+        }),
+        prisma.investmentMovement.findMany({
+            where: movementWhere,
+            include: {account: true, instrument: true},
+            orderBy: [{operationDate: 'asc'}, {id: 'asc'}],
+        }),
+    ])
+
+    const positionIds = positions.map((position) => position.id)
+    const marketInstrumentIds = positions
+        .map((position) => position.instrument?.marketInstrumentId)
+        .filter((id) => id != null)
+
+    const priceSnapshots = positionIds.length || marketInstrumentIds.length
+        ? await prisma.priceSnapshot.findMany({
+            where: {
+                OR: [
+                    positionIds.length ? {investmentPositionId: {in: positionIds}} : undefined,
+                    marketInstrumentIds.length ? {marketInstrumentId: {in: marketInstrumentIds}} : undefined,
+                ].filter(Boolean),
+            },
+            orderBy: [{pricedAt: 'desc'}, {id: 'desc'}],
+        })
+        : []
+
+    return {positions, movements, priceSnapshots}
+}
+
+async function getPortfolioDashboard(input = {}, dependencies = {}) {
+    const asOf = normalizeDate(input.asOf || dependencies.asOf || new Date())
+    const baseCurrency = currency(input.baseCurrency || input.currency || dependencies.baseCurrency, 'CAD')
+    const source = input.positions
+        ? {positions: input.positions, movements: input.movements || [], priceSnapshots: input.priceSnapshots || []}
+        : await loadPortfolioDashboardSource(dependencies.prisma, input)
+
+    const sharedInput = {
+        ...input,
+        baseCurrency,
+        asOf,
+        positions: source.positions,
+        movements: source.movements,
+        priceSnapshots: source.priceSnapshots,
+    }
+
+    const [allocations, income, history] = await Promise.all([
+        calculatePortfolioAllocations(sharedInput, dependencies),
+        calculatePortfolioIncome({
+            ...sharedInput,
+            period: input.incomePeriod || 'currentMonth',
+            now: asOf,
+            startDate: input.incomeStartDate,
+            endDate: input.incomeEndDate,
+        }, dependencies),
+        input.history
+            ? Promise.resolve({snapshots: input.history})
+            : readPortfolioSnapshotHistory({
+                portfolioId: input.portfolioId,
+                currency: baseCurrency,
+                startDate: input.historyStartDate || isoDate(monthsAgo(asOf, 12)),
+                endDate: input.historyEndDate || isoDate(endExclusiveOfNextDay(asOf)),
+            }, dependencies),
+    ])
+
+    return buildPortfolioDashboardState({
+        allocations,
+        income,
+        history,
+        baseCurrency,
+        asOf,
+        portfolioId: input.portfolioId ?? null,
+    })
+}
+
+module.exports = {
+    buildPortfolioDashboardState,
+    getPortfolioDashboard,
+    loadPortfolioDashboardSource,
+    summarizeDataStatus,
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -96,4 +96,5 @@ contextBridge.exposeInMainWorld('wealth', {
   getOverview: (options) => ipcRenderer.invoke('db:wealth:overview', options),
   createGeneratedNetWorthSnapshot: (options) => ipcRenderer.invoke('db:netWorthSnapshot:createGenerated', options),
   listNetWorthSnapshots: (filters) => ipcRenderer.invoke('db:netWorthSnapshot:list', filters),
+  getPortfolioAnalyticsDashboard: (options) => ipcRenderer.invoke('db:portfolioAnalytics:dashboard', options),
 })

--- a/src/components/PortfolioAnalyticsDashboard.vue
+++ b/src/components/PortfolioAnalyticsDashboard.vue
@@ -1,0 +1,256 @@
+<script setup lang="ts">
+import {computed, onMounted, ref, watch} from 'vue'
+
+type AllocationGroup = {
+  key: string
+  label: string
+  marketValue: number
+  allocationPercent: number
+  positionsCount: number
+  completenessStatus: 'complete' | 'partial' | 'missing' | string
+}
+
+type PortfolioHistoryPoint = {
+  id: number
+  snapshotDate: string
+  totalMarketValue: number
+  totalInvestedCost: number
+  totalUnrealizedGain: number
+  currency: string
+  completenessStatus: string
+}
+
+type PortfolioDashboard = {
+  baseCurrency: string
+  asOf: string
+  isEmpty: boolean
+  hasNoPrice: boolean
+  hasHistory: boolean
+  kpis: {
+    totalMarketValue: number
+    totalInvestedCost: number
+    totalUnrealizedGain: number
+    totalUnrealizedGainPercent: number | null
+    periodIncome: number
+    periodFees: number
+    netIncome: number
+    grossReturnSimple: number | null
+  }
+  allocationBlocks: Record<'asset' | 'assetClass' | 'sector' | 'geography' | 'currency', AllocationGroup[]>
+  dataStatus: {fresh: number; stale: number; missing: number; manual: number; error: number; total: number}
+  history: PortfolioHistoryPoint[]
+  warnings: {positionId: number | null; warning: string}[]
+}
+
+const props = withDefaults(defineProps<{summaryCurrency?: string}>(), {summaryCurrency: 'CAD'})
+const emit = defineEmits<{(event: 'create-asset'): void; (event: 'create-movement'): void}>()
+
+const dashboard = ref<PortfolioDashboard | null>(null)
+const loading = ref(false)
+const errorMessage = ref<string | null>(null)
+
+const allocationTabs = [
+  {key: 'asset' as const, label: 'Actifs'},
+  {key: 'assetClass' as const, label: 'Classes'},
+  {key: 'sector' as const, label: 'Secteurs'},
+  {key: 'geography' as const, label: 'Géographies'},
+  {key: 'currency' as const, label: 'Devises'},
+]
+
+const activeAllocation = ref<(typeof allocationTabs)[number]['key']>('asset')
+
+async function loadDashboard() {
+  if (!window.wealth?.getPortfolioAnalyticsDashboard) {
+    errorMessage.value = 'API Portfolio analytics indisponible.'
+    return
+  }
+
+  loading.value = true
+  errorMessage.value = null
+
+  try {
+    dashboard.value = await window.wealth.getPortfolioAnalyticsDashboard({
+      baseCurrency: props.summaryCurrency,
+      incomePeriod: 'currentMonth',
+    })
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Impossible de charger le dashboard portefeuille.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatMoney(amount: number | null | undefined, currency = dashboard.value?.baseCurrency || props.summaryCurrency) {
+  if (amount == null) return '—'
+  return new Intl.NumberFormat(undefined, {style: 'currency', currency, maximumFractionDigits: 0}).format(Number(amount || 0))
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (value == null) return '—'
+  return new Intl.NumberFormat(undefined, {maximumFractionDigits: 1}).format(Number(value)) + '%'
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—'
+  return new Intl.DateTimeFormat(undefined, {dateStyle: 'medium'}).format(new Date(value))
+}
+
+const kpiCards = computed(() => {
+  const kpis = dashboard.value?.kpis
+  return [
+    {label: 'Valeur totale', value: formatMoney(kpis?.totalMarketValue), hint: 'Valorisation actuelle'},
+    {label: 'Coût investi', value: formatMoney(kpis?.totalInvestedCost), hint: 'Coût moyen pondéré'},
+    {label: 'Plus-value latente', value: formatMoney(kpis?.totalUnrealizedGain), hint: formatPercent(kpis?.totalUnrealizedGainPercent)},
+    {label: 'Revenus période', value: formatMoney(kpis?.periodIncome), hint: `Frais ${formatMoney(kpis?.periodFees)}`},
+    {label: 'Net revenus', value: formatMoney(kpis?.netIncome), hint: 'Revenus - frais'},
+  ]
+})
+
+const currentAllocationRows = computed(() => dashboard.value?.allocationBlocks?.[activeAllocation.value] || [])
+const topHistory = computed(() => dashboard.value?.history?.slice(-8) || [])
+const historyMax = computed(() => Math.max(1, ...topHistory.value.map((point) => Math.max(point.totalMarketValue, point.totalInvestedCost))))
+
+function barWidth(value: number | null | undefined, denominator = 100) {
+  if (!value || denominator <= 0) return '0%'
+  return `${Math.max(0, Math.min(100, (value / denominator) * 100))}%`
+}
+
+function statusTone(status: string) {
+  if (status === 'complete' || status === 'COMPLETE') return 'text-emerald-300 bg-emerald-950/50 border-emerald-900/70'
+  if (status === 'partial' || status === 'PARTIAL') return 'text-amber-300 bg-amber-950/50 border-amber-900/70'
+  return 'text-slate-300 bg-slate-900 border-slate-800'
+}
+
+watch(() => props.summaryCurrency, () => void loadDashboard())
+onMounted(() => void loadDashboard())
+</script>
+
+<template>
+  <section class="space-y-5 rounded-[2rem] border border-slate-800 bg-slate-950 p-5 shadow-sm">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.24em] text-violet-300">Portfolio analytics</p>
+        <h3 class="mt-2 text-2xl font-semibold text-white">Cockpit portefeuille MVP</h3>
+        <p class="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
+          KPI, allocations, qualité de données et historique local via IPC, sans lecture Prisma côté renderer.
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button class="rounded-2xl border border-violet-700 bg-violet-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-violet-500" @click="emit('create-asset')">
+          Ajouter un actif
+        </button>
+        <button class="rounded-2xl border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-800" @click="emit('create-movement')">
+          Saisir un mouvement
+        </button>
+        <button class="rounded-2xl border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-800 disabled:opacity-60" :disabled="loading" @click="loadDashboard">
+          {{ loading ? 'Chargement…' : 'Rafraîchir' }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="errorMessage" class="rounded-2xl border border-red-900/60 bg-red-950/40 px-4 py-3 text-sm text-red-200">
+      {{ errorMessage }}
+    </div>
+
+    <div v-if="dashboard?.isEmpty" class="rounded-[1.5rem] border border-dashed border-slate-700 bg-slate-900/60 p-6 text-center">
+      <p class="text-lg font-semibold text-white">Aucun actif de portefeuille pour l’instant.</p>
+      <p class="mt-2 text-sm text-slate-400">Ajoute une position ou saisis un mouvement pour activer les KPI, allocations et historique.</p>
+      <button class="mt-4 rounded-2xl bg-violet-600 px-4 py-2 text-sm font-semibold text-white hover:bg-violet-500" @click="emit('create-asset')">
+        Ajouter un actif
+      </button>
+    </div>
+
+    <template v-else>
+      <div class="grid gap-3 md:grid-cols-5">
+        <article v-for="card in kpiCards" :key="card.label" class="rounded-[1.5rem] border border-slate-800 bg-slate-900/70 p-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{{ card.label }}</p>
+          <p class="mt-3 text-2xl font-semibold text-white">{{ card.value }}</p>
+          <p class="mt-1 text-sm text-slate-400">{{ card.hint }}</p>
+        </article>
+      </div>
+
+      <div v-if="dashboard?.hasNoPrice" class="rounded-2xl border border-amber-900/60 bg-amber-950/40 px-4 py-3 text-sm text-amber-100">
+        Aucun prix exploitable pour les positions actuelles. Les gains et allocations restent visibles, mais les valeurs de marché sont incomplètes.
+      </div>
+
+      <div class="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(340px,1fr)]">
+        <article class="rounded-[1.5rem] border border-slate-800 bg-slate-900/50 p-4">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h4 class="text-lg font-semibold text-white">Allocations</h4>
+              <p class="text-sm text-slate-400">Top expositions du portefeuille valorisé.</p>
+            </div>
+            <div class="flex flex-wrap gap-1 rounded-2xl bg-slate-950 p-1">
+              <button v-for="tab in allocationTabs" :key="tab.key" class="rounded-xl px-3 py-1.5 text-xs font-semibold transition" :class="activeAllocation === tab.key ? 'bg-white text-slate-950' : 'text-slate-400 hover:text-white'" @click="activeAllocation = tab.key">
+                {{ tab.label }}
+              </button>
+            </div>
+          </div>
+
+          <div class="mt-4 space-y-3">
+            <div v-for="row in currentAllocationRows.slice(0, 8)" :key="row.key" class="rounded-2xl border border-slate-800 bg-slate-950/60 p-3">
+              <div class="flex items-center justify-between gap-3">
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-semibold text-white">{{ row.label }}</p>
+                  <p class="text-xs text-slate-500">{{ row.positionsCount }} position(s) · {{ formatMoney(row.marketValue) }}</p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="rounded-full border px-2 py-1 text-[11px] font-semibold" :class="statusTone(row.completenessStatus)">{{ row.completenessStatus }}</span>
+                  <span class="text-sm font-semibold text-violet-200">{{ formatPercent(row.allocationPercent) }}</span>
+                </div>
+              </div>
+              <div class="mt-3 h-2 overflow-hidden rounded-full bg-slate-800">
+                <div class="h-full rounded-full bg-violet-500" :style="{width: barWidth(row.allocationPercent)}" />
+              </div>
+            </div>
+
+            <p v-if="currentAllocationRows.length === 0" class="rounded-2xl border border-dashed border-slate-800 px-4 py-6 text-center text-sm text-slate-400">
+              Aucune allocation disponible.
+            </p>
+          </div>
+        </article>
+
+        <aside class="space-y-5">
+          <article class="rounded-[1.5rem] border border-slate-800 bg-slate-900/50 p-4">
+            <h4 class="text-lg font-semibold text-white">Statut des données</h4>
+            <div class="mt-4 grid grid-cols-2 gap-2 text-sm">
+              <div class="rounded-2xl border border-emerald-900/60 bg-emerald-950/40 p-3 text-emerald-100">Prix frais <strong class="float-right">{{ dashboard?.dataStatus.fresh || 0 }}</strong></div>
+              <div class="rounded-2xl border border-amber-900/60 bg-amber-950/40 p-3 text-amber-100">Stale <strong class="float-right">{{ dashboard?.dataStatus.stale || 0 }}</strong></div>
+              <div class="rounded-2xl border border-violet-900/60 bg-violet-950/40 p-3 text-violet-100">Manuel <strong class="float-right">{{ dashboard?.dataStatus.manual || 0 }}</strong></div>
+              <div class="rounded-2xl border border-slate-800 bg-slate-950 p-3 text-slate-200">Manquant <strong class="float-right">{{ dashboard?.dataStatus.missing || 0 }}</strong></div>
+            </div>
+          </article>
+
+          <article class="rounded-[1.5rem] border border-slate-800 bg-slate-900/50 p-4">
+            <h4 class="text-lg font-semibold text-white">Historique local</h4>
+            <p class="text-sm text-slate-400">Valeur, coût et plus-value depuis les snapshots locaux.</p>
+            <div v-if="!dashboard?.hasHistory" class="mt-4 rounded-2xl border border-dashed border-slate-800 px-4 py-6 text-center text-sm text-slate-400">
+              Aucun historique. Crée un snapshot pour suivre l’évolution.
+            </div>
+            <div v-else class="mt-4 space-y-3">
+              <div v-for="point in topHistory" :key="point.id" class="space-y-1">
+                <div class="flex items-center justify-between text-xs text-slate-400">
+                  <span>{{ formatDate(point.snapshotDate) }}</span>
+                  <span>{{ formatMoney(point.totalMarketValue, point.currency) }}</span>
+                </div>
+                <div class="h-2 overflow-hidden rounded-full bg-slate-800">
+                  <div class="h-full rounded-full bg-emerald-500" :style="{width: barWidth(point.totalMarketValue, historyMax)}" />
+                </div>
+                <div class="h-1.5 overflow-hidden rounded-full bg-slate-800/80">
+                  <div class="h-full rounded-full bg-violet-500" :style="{width: barWidth(point.totalInvestedCost, historyMax)}" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </aside>
+      </div>
+
+      <div v-if="dashboard?.warnings?.length" class="rounded-2xl border border-amber-900/60 bg-amber-950/30 p-4 text-sm text-amber-100">
+        <p class="font-semibold">Calculs partiels</p>
+        <ul class="mt-2 list-disc space-y-1 pl-5">
+          <li v-for="(warning, index) in dashboard.warnings.slice(0, 4)" :key="index">{{ warning.warning }}</li>
+        </ul>
+      </div>
+    </template>
+  </section>
+</template>

--- a/src/components/PortfolioAnalyticsDashboard.vue
+++ b/src/components/PortfolioAnalyticsDashboard.vue
@@ -42,6 +42,10 @@ type PortfolioDashboard = {
   warnings: {positionId: number | null; warning: string}[]
 }
 
+type PortfolioAnalyticsRendererApi = {
+  getPortfolioAnalyticsDashboard?: (options?: Record<string, unknown>) => Promise<PortfolioDashboard>
+}
+
 const props = withDefaults(defineProps<{summaryCurrency?: string}>(), {summaryCurrency: 'CAD'})
 const emit = defineEmits<{(event: 'create-asset'): void; (event: 'create-movement'): void}>()
 
@@ -59,8 +63,13 @@ const allocationTabs = [
 
 const activeAllocation = ref<(typeof allocationTabs)[number]['key']>('asset')
 
+function portfolioAnalyticsApi(): PortfolioAnalyticsRendererApi | null {
+  return (window as unknown as {wealth?: PortfolioAnalyticsRendererApi}).wealth || null
+}
+
 async function loadDashboard() {
-  if (!window.wealth?.getPortfolioAnalyticsDashboard) {
+  const api = portfolioAnalyticsApi()
+  if (!api?.getPortfolioAnalyticsDashboard) {
     errorMessage.value = 'API Portfolio analytics indisponible.'
     return
   }
@@ -69,7 +78,7 @@ async function loadDashboard() {
   errorMessage.value = null
 
   try {
-    dashboard.value = await window.wealth.getPortfolioAnalyticsDashboard({
+    dashboard.value = await api.getPortfolioAnalyticsDashboard({
       baseCurrency: props.summaryCurrency,
       incomePeriod: 'currentMonth',
     })

--- a/src/test/electron/portfolioDashboardService.test.js
+++ b/src/test/electron/portfolioDashboardService.test.js
@@ -1,0 +1,126 @@
+const {describe, expect, it} = require('vitest')
+const {
+    buildPortfolioDashboardState,
+    getPortfolioDashboard,
+    summarizeDataStatus,
+} = require('../../../electron/portfolio/portfolioDashboardService')
+
+const positions = [
+    {
+        id: 1,
+        accountId: 10,
+        accountName: 'Brokerage',
+        instrumentId: 100,
+        marketInstrumentId: 500,
+        currency: 'CAD',
+        instrument: {
+            id: 100,
+            symbol: 'XEQT',
+            name: 'XEQT ETF',
+            assetClass: 'ETF',
+            sector: 'Diversified',
+            geographicRegion: 'Global',
+            currency: 'CAD',
+            marketInstrumentId: 500,
+        },
+    },
+    {
+        id: 2,
+        accountId: 10,
+        accountName: 'Brokerage',
+        instrumentId: 101,
+        marketInstrumentId: null,
+        currency: 'CAD',
+        costBasis: 300,
+        instrument: {
+            id: 101,
+            symbol: 'PRIVATE',
+            name: 'Private asset',
+            assetClass: null,
+            sector: null,
+            geographicRegion: null,
+            currency: 'CAD',
+            marketInstrumentId: null,
+        },
+    },
+]
+
+const movements = [
+    {id: 1, type: 'BUY', positionId: 1, quantity: 10, unitPrice: 100, priceCurrency: 'CAD', feeAmount: 0, operationDate: '2026-04-01'},
+    {id: 2, type: 'DIVIDEND', positionId: 1, instrumentId: 100, accountId: 10, cashAmount: 25, cashCurrency: 'CAD', operationDate: '2026-04-15'},
+    {id: 3, type: 'FEE', accountId: 10, cashAmount: 5, cashCurrency: 'CAD', operationDate: '2026-04-16'},
+]
+
+const priceSnapshots = [
+    {id: 1, marketInstrumentId: 500, unitPrice: 120, currency: 'CAD', pricedAt: '2026-04-29', freshnessStatus: 'FRESH'},
+]
+
+describe('portfolio dashboard service', () => {
+    it('summarizes data statuses for fresh, stale, manual and missing positions', () => {
+        expect(summarizeDataStatus([
+            {valuationStatus: 'market'},
+            {valuationStatus: 'stale'},
+            {valuationStatus: 'manual'},
+            {valuationStatus: 'missing'},
+            {valuationStatus: 'error'},
+        ])).toEqual({fresh: 1, stale: 1, missing: 1, manual: 1, error: 1, total: 5})
+    })
+
+    it('builds dashboard-ready KPI, allocation, income and status blocks from raw inputs', async () => {
+        const dashboard = await getPortfolioDashboard({
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+            positions,
+            movements,
+            priceSnapshots,
+            incomeStartDate: '2026-04-01',
+            incomeEndDate: '2026-05-01',
+            history: [
+                {id: 1, snapshotDate: '2026-04-01', totalMarketValue: 1000, totalInvestedCost: 1000, totalUnrealizedGain: 0, currency: 'CAD', completenessStatus: 'COMPLETE', source: 'MANUAL'},
+                {id: 2, snapshotDate: '2026-04-30', totalMarketValue: 1200, totalInvestedCost: 1000, totalUnrealizedGain: 200, currency: 'CAD', completenessStatus: 'PARTIAL', source: 'MANUAL'},
+            ],
+        })
+
+        expect(dashboard.kpis).toMatchObject({
+            totalMarketValue: 1200,
+            totalInvestedCost: 1300,
+            totalUnrealizedGain: 200,
+            periodIncome: 25,
+            periodFees: 5,
+            netIncome: 20,
+        })
+        expect(dashboard.dataStatus).toMatchObject({fresh: 1, missing: 1, total: 2})
+        expect(dashboard.allocationBlocks.assetClass).toEqual(expect.arrayContaining([
+            expect.objectContaining({key: 'etf', marketValue: 1200, allocationPercent: 100}),
+            expect.objectContaining({key: 'unknown', marketValue: 0, allocationPercent: 0, completenessStatus: 'missing'}),
+        ]))
+        expect(dashboard.history).toHaveLength(2)
+        expect(dashboard.isEmpty).toBe(false)
+        expect(dashboard.hasNoPrice).toBe(false)
+        expect(dashboard.hasHistory).toBe(true)
+    })
+
+    it('does not break on an empty portfolio', () => {
+        const dashboard = buildPortfolioDashboardState({
+            allocations: {positions: [], totals: {}, allocations: {byGroup: {}}},
+            income: {summary: {totalIncome: 0, totalFees: 0, netIncome: 0}},
+            history: {snapshots: []},
+            baseCurrency: 'CAD',
+            asOf: '2026-04-30',
+        })
+
+        expect(dashboard).toMatchObject({
+            isEmpty: true,
+            hasNoPrice: false,
+            hasHistory: false,
+            kpis: {
+                totalMarketValue: 0,
+                totalInvestedCost: 0,
+                totalUnrealizedGain: 0,
+                periodIncome: 0,
+                periodFees: 0,
+                netIncome: 0,
+            },
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Closes #48.

- Add a portfolio dashboard aggregation service that combines valuation, gain metrics, allocations, income/fees and local snapshot history.
- Expose the dashboard through IPC and preload via `window.wealth.getPortfolioAnalyticsDashboard`, so the renderer does not read Prisma directly.
- Add a Vue `PortfolioAnalyticsDashboard` component with KPI cards, allocation tabs, data status cards, simple local history bars, warning states and clean empty/no-price/no-history states.
- Add CTA hooks for adding an asset and entering movements.
- Add unit tests for dashboard aggregation, data statuses and empty portfolio behavior.

## Validation

- Added Vitest unit coverage for the dashboard aggregation service.
- I could not run the repository's full `npm run check` locally because the sandbox does not have the repo dependencies installed. CI should be treated as source of truth.

Base branch: `epic4`.