### PR TITLE
security: add encrypted backup primitives

### DIFF
--- a/docs/backup-format.md
+++ b/docs/backup-format.md
@@ -30,6 +30,49 @@ Version `5` added goals and projections. Version `6` adds import pipeline data w
 
 Legacy versions are normalized with empty goal/projection/import arrays so older backups remain restorable.
 
+## Encrypted local backup envelope
+
+Encrypted local backups wrap the canonical JSON backup in a separate versioned envelope. The encrypted envelope is not a replacement for the canonical backup schema: after decryption, the plaintext must still parse as a normal `budget-backup` JSON document.
+
+The initial encrypted format is:
+
+```json
+{
+  "kind": "budget-encrypted-backup",
+  "version": 1,
+  "cipher": "aes-256-gcm",
+  "kdf": {
+    "name": "scrypt",
+    "saltEncoding": "base64",
+    "keyLength": 64,
+    "N": 16384,
+    "r": 8,
+    "p": 1
+  },
+  "salt": "base64-random-salt",
+  "nonce": "base64-random-nonce",
+  "ciphertext": "base64-ciphertext",
+  "authTag": "base64-authentication-tag",
+  "keyCheck": "base64-password-check",
+  "createdAt": "2026-05-01T00:00:00.000Z",
+  "metadata": {
+    "contentType": "application/json",
+    "purpose": "local-backup-export"
+  }
+}
+```
+
+Properties:
+
+- `salt` is random for each export and is used by `scrypt`.
+- `nonce` is random for each export and is used by AES-GCM.
+- `ciphertext` contains the encrypted canonical JSON backup.
+- `authTag` authenticates the encrypted content and associated metadata.
+- `keyCheck` lets the app fail clearly on a wrong password before attempting plaintext recovery.
+- `metadata` must stay minimal and non-sensitive.
+
+The encryption helper lives outside Vue and Prisma so encrypted export/restore flows can reuse it from Electron main without coupling it to UI state or database access.
+
 ## Goals
 
 `data.financialGoals` stores user goals independently from database ids that may change during restore.

--- a/electron/security/backupEncryption.js
+++ b/electron/security/backupEncryption.js
@@ -1,0 +1,451 @@
+const crypto = require('node:crypto')
+
+const ENCRYPTED_BACKUP_KIND = 'budget-encrypted-backup'
+const ENCRYPTED_BACKUP_VERSION = 1
+const ENCRYPTED_BACKUP_CIPHER = 'aes-256-gcm'
+const ENCRYPTED_BACKUP_KDF = 'scrypt'
+
+const BACKUP_ENCRYPTION_ERROR_CODES = Object.freeze({
+    INVALID_ENCRYPTED_BACKUP: 'invalidEncryptedBackup',
+    WRONG_PASSWORD: 'wrongPassword',
+    UNSUPPORTED_ENCRYPTION_VERSION: 'unsupportedEncryptionVersion',
+    CORRUPTED_CIPHERTEXT: 'corruptedCiphertext',
+    INVALID_INPUT: 'invalidEncryptionInput',
+})
+
+const DEFAULT_KDF_PARAMS = Object.freeze({
+    name: ENCRYPTED_BACKUP_KDF,
+    saltEncoding: 'base64',
+    keyLength: 64,
+    N: 16384,
+    r: 8,
+    p: 1,
+})
+
+const DEFAULT_METADATA = Object.freeze({
+    contentType: 'application/json',
+    purpose: 'local-backup-export',
+})
+
+class BackupEncryptionError extends Error {
+    constructor(code, message, details = null, recoverable = true) {
+        super(message)
+        this.name = 'BackupEncryptionError'
+        this.code = code
+        this.details = details
+        this.recoverable = recoverable
+    }
+}
+
+function isRecord(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value))
+}
+
+function nowIso(now = () => new Date()) {
+    const value = typeof now === 'function' ? now() : now
+    const date = value instanceof Date ? value : new Date(value)
+    return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString()
+}
+
+function fail(code, message, details = null, recoverable = true) {
+    throw new BackupEncryptionError(code, message, details, recoverable)
+}
+
+function normalizePassword(password) {
+    if (typeof password !== 'string' || password.length === 0) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+            'Un mot de passe non vide est obligatoire pour chiffrer ou déchiffrer le backup.',
+        )
+    }
+    return password
+}
+
+function normalizeBackupJson(backupJson) {
+    if (typeof backupJson !== 'string' || !backupJson.trim()) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+            'Le backup JSON à chiffrer doit être une chaîne non vide.',
+        )
+    }
+
+    try {
+        JSON.parse(backupJson)
+    } catch (_error) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+            'Le contenu à chiffrer doit être un JSON valide.',
+        )
+    }
+
+    return backupJson
+}
+
+function normalizeMetadata(metadata = {}) {
+    if (metadata == null) return clone(DEFAULT_METADATA)
+    if (!isRecord(metadata)) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+            'Les métadonnées de backup chiffré doivent être un objet simple.',
+        )
+    }
+
+    const normalized = {...DEFAULT_METADATA}
+
+    for (const [key, value] of Object.entries(metadata)) {
+        if (!/^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/.test(key)) {
+            fail(
+                BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+                'Une clé de métadonnées de backup chiffré est invalide.',
+                {key},
+            )
+        }
+
+        if (value == null || ['string', 'number', 'boolean'].includes(typeof value)) {
+            normalized[key] = value
+        } else {
+            fail(
+                BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+                'Les métadonnées de backup chiffré doivent rester scalaires et non sensibles.',
+                {key},
+            )
+        }
+    }
+
+    return normalized
+}
+
+function base64Encode(buffer) {
+    return Buffer.from(buffer).toString('base64')
+}
+
+function base64Decode(value, fieldName) {
+    if (typeof value !== 'string' || !value.length) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            `Le champ ${fieldName} du backup chiffré est obligatoire.`,
+            {fieldName},
+        )
+    }
+
+    try {
+        const decoded = Buffer.from(value, 'base64')
+        if (!decoded.length || base64Encode(decoded) !== value) {
+            throw new Error('Invalid base64')
+        }
+        return decoded
+    } catch (_error) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.CORRUPTED_CIPHERTEXT,
+            `Le champ ${fieldName} du backup chiffré n’est pas un base64 valide.`,
+            {fieldName},
+        )
+    }
+}
+
+function normalizePositiveInteger(value, fieldName) {
+    if (!Number.isInteger(value) || value <= 0) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            `Le paramètre ${fieldName} du KDF est invalide.`,
+            {fieldName, value},
+        )
+    }
+    return value
+}
+
+function normalizeKdf(kdf) {
+    if (!isRecord(kdf)) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le backup chiffré doit déclarer un KDF.',
+        )
+    }
+
+    if (kdf.name !== ENCRYPTED_BACKUP_KDF) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le KDF du backup chiffré n’est pas supporté.',
+            {kdf: kdf.name || null},
+        )
+    }
+
+    return {
+        name: ENCRYPTED_BACKUP_KDF,
+        saltEncoding: kdf.saltEncoding === 'base64' ? 'base64' : 'base64',
+        keyLength: normalizePositiveInteger(kdf.keyLength, 'keyLength'),
+        N: normalizePositiveInteger(kdf.N, 'N'),
+        r: normalizePositiveInteger(kdf.r, 'r'),
+        p: normalizePositiveInteger(kdf.p, 'p'),
+    }
+}
+
+function deriveKeys(password, salt, kdf = DEFAULT_KDF_PARAMS) {
+    const normalizedPassword = normalizePassword(password)
+    const normalizedKdf = normalizeKdf(kdf)
+    const keyMaterial = crypto.scryptSync(normalizedPassword, salt, normalizedKdf.keyLength, {
+        N: normalizedKdf.N,
+        r: normalizedKdf.r,
+        p: normalizedKdf.p,
+        maxmem: 64 * 1024 * 1024,
+    })
+
+    if (keyMaterial.length < 64) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'La dérivation de clé n’a pas produit assez de matière cryptographique.',
+        )
+    }
+
+    return {
+        encryptionKey: keyMaterial.subarray(0, 32),
+        verifierKey: keyMaterial.subarray(32, 64),
+    }
+}
+
+function stableJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableJson).join(',')}]`
+    }
+
+    if (isRecord(value)) {
+        return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`
+    }
+
+    return JSON.stringify(value)
+}
+
+function buildAssociatedData(envelope) {
+    const aad = {
+        kind: envelope.kind,
+        version: envelope.version,
+        cipher: envelope.cipher,
+        kdf: envelope.kdf,
+        salt: envelope.salt,
+        nonce: envelope.nonce,
+        createdAt: envelope.createdAt,
+        metadata: envelope.metadata || {},
+    }
+    return Buffer.from(stableJson(aad), 'utf8')
+}
+
+function createPasswordVerifier(verifierKey, associatedData) {
+    return crypto
+        .createHmac('sha256', verifierKey)
+        .update('budget-encrypted-backup-password-verifier')
+        .update(associatedData)
+        .digest()
+}
+
+function assertEnvelopeVersion(version) {
+    if (version !== ENCRYPTED_BACKUP_VERSION) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.UNSUPPORTED_ENCRYPTION_VERSION,
+            `Version de backup chiffré non supportée (${version}).`,
+            {version, supportedVersions: [ENCRYPTED_BACKUP_VERSION]},
+        )
+    }
+}
+
+function normalizeEnvelope(input) {
+    let envelope = input
+
+    if (typeof input === 'string') {
+        try {
+            envelope = JSON.parse(input)
+        } catch (_error) {
+            fail(
+                BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+                'Le backup chiffré doit être un JSON valide.',
+            )
+        }
+    }
+
+    if (!isRecord(envelope)) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le backup chiffré doit être un objet.',
+        )
+    }
+
+    if (envelope.kind !== ENCRYPTED_BACKUP_KIND) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le fichier ne correspond pas à un backup chiffré Budget valide.',
+            {kind: envelope.kind || null},
+        )
+    }
+
+    assertEnvelopeVersion(envelope.version)
+
+    if (envelope.cipher !== ENCRYPTED_BACKUP_CIPHER) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le chiffrement du backup n’est pas supporté.',
+            {cipher: envelope.cipher || null},
+        )
+    }
+
+    if (typeof envelope.createdAt !== 'string' || Number.isNaN(Date.parse(envelope.createdAt))) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+            'Le backup chiffré doit déclarer une date createdAt valide.',
+        )
+    }
+
+    const kdf = normalizeKdf(envelope.kdf)
+    const metadata = normalizeMetadata(envelope.metadata || {})
+
+    return {
+        kind: ENCRYPTED_BACKUP_KIND,
+        version: ENCRYPTED_BACKUP_VERSION,
+        cipher: ENCRYPTED_BACKUP_CIPHER,
+        kdf,
+        salt: envelope.salt,
+        nonce: envelope.nonce,
+        ciphertext: envelope.ciphertext,
+        authTag: envelope.authTag,
+        keyCheck: envelope.keyCheck,
+        createdAt: envelope.createdAt,
+        metadata,
+    }
+}
+
+function encryptBackupJson(backupJson, password, options = {}) {
+    const plaintext = normalizeBackupJson(backupJson)
+    const metadata = normalizeMetadata(options.metadata || {})
+    const salt = crypto.randomBytes(options.saltBytes || 16)
+    const nonce = crypto.randomBytes(options.nonceBytes || 12)
+    const createdAt = nowIso(options.now)
+    const kdf = {...DEFAULT_KDF_PARAMS}
+    const keys = deriveKeys(password, salt, kdf)
+
+    const envelopeBase = {
+        kind: ENCRYPTED_BACKUP_KIND,
+        version: ENCRYPTED_BACKUP_VERSION,
+        cipher: ENCRYPTED_BACKUP_CIPHER,
+        kdf,
+        salt: base64Encode(salt),
+        nonce: base64Encode(nonce),
+        createdAt,
+        metadata,
+    }
+    const associatedData = buildAssociatedData(envelopeBase)
+    const cipher = crypto.createCipheriv(ENCRYPTED_BACKUP_CIPHER, keys.encryptionKey, nonce)
+    cipher.setAAD(associatedData)
+    const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ])
+    const authTag = cipher.getAuthTag()
+    const keyCheck = createPasswordVerifier(keys.verifierKey, associatedData)
+
+    return {
+        ...envelopeBase,
+        ciphertext: base64Encode(ciphertext),
+        authTag: base64Encode(authTag),
+        keyCheck: base64Encode(keyCheck),
+    }
+}
+
+function decryptBackupJson(input, password) {
+    const envelope = normalizeEnvelope(input)
+    const salt = base64Decode(envelope.salt, 'salt')
+    const nonce = base64Decode(envelope.nonce, 'nonce')
+    const ciphertext = base64Decode(envelope.ciphertext, 'ciphertext')
+    const authTag = base64Decode(envelope.authTag, 'authTag')
+    const keyCheck = base64Decode(envelope.keyCheck, 'keyCheck')
+
+    if (nonce.length !== 12) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.CORRUPTED_CIPHERTEXT,
+            'Le nonce du backup chiffré a une taille invalide.',
+            {nonceLength: nonce.length},
+        )
+    }
+
+    if (authTag.length !== 16) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.CORRUPTED_CIPHERTEXT,
+            'Le tag d’authentification du backup chiffré a une taille invalide.',
+            {authTagLength: authTag.length},
+        )
+    }
+
+    const keys = deriveKeys(password, salt, envelope.kdf)
+    const associatedData = buildAssociatedData(envelope)
+    const expectedKeyCheck = createPasswordVerifier(keys.verifierKey, associatedData)
+
+    if (keyCheck.length !== expectedKeyCheck.length || !crypto.timingSafeEqual(keyCheck, expectedKeyCheck)) {
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.WRONG_PASSWORD,
+            'Le mot de passe du backup chiffré est incorrect.',
+        )
+    }
+
+    try {
+        const decipher = crypto.createDecipheriv(ENCRYPTED_BACKUP_CIPHER, keys.encryptionKey, nonce)
+        decipher.setAAD(associatedData)
+        decipher.setAuthTag(authTag)
+        const plaintext = Buffer.concat([
+            decipher.update(ciphertext),
+            decipher.final(),
+        ]).toString('utf8')
+
+        normalizeBackupJson(plaintext)
+        return plaintext
+    } catch (error) {
+        if (error instanceof BackupEncryptionError) throw error
+        fail(
+            BACKUP_ENCRYPTION_ERROR_CODES.CORRUPTED_CIPHERTEXT,
+            'Le contenu chiffré du backup est corrompu ou a été modifié.',
+            {cause: error.message || null},
+        )
+    }
+}
+
+function serializeEncryptedBackup(envelope) {
+    const normalized = normalizeEnvelope(envelope)
+    return `${JSON.stringify(normalized, null, 2)}\n`
+}
+
+function parseEncryptedBackup(content) {
+    return normalizeEnvelope(content)
+}
+
+function toBackupEncryptionIpcError(error) {
+    if (error instanceof BackupEncryptionError) {
+        return {
+            code: error.code,
+            message: error.message,
+            details: error.details || null,
+            recoverable: error.recoverable !== false,
+        }
+    }
+
+    return {
+        code: error?.code || BACKUP_ENCRYPTION_ERROR_CODES.INVALID_ENCRYPTED_BACKUP,
+        message: error?.message || 'Erreur de chiffrement de backup inconnue.',
+        details: error?.details || null,
+        recoverable: true,
+    }
+}
+
+module.exports = {
+    BACKUP_ENCRYPTION_ERROR_CODES,
+    DEFAULT_KDF_PARAMS,
+    ENCRYPTED_BACKUP_CIPHER,
+    ENCRYPTED_BACKUP_KDF,
+    ENCRYPTED_BACKUP_KIND,
+    ENCRYPTED_BACKUP_VERSION,
+    BackupEncryptionError,
+    decryptBackupJson,
+    encryptBackupJson,
+    parseEncryptedBackup,
+    serializeEncryptedBackup,
+    toBackupEncryptionIpcError,
+}

--- a/src/test/electron/backupEncryption.test.js
+++ b/src/test/electron/backupEncryption.test.js
@@ -1,0 +1,144 @@
+import {describe, expect, it} from 'vitest'
+
+function loadBackupEncryption() {
+    return require('../../../electron/security/backupEncryption')
+}
+
+function sampleBackupJson() {
+    return JSON.stringify({
+        kind: 'budget-backup',
+        version: 6,
+        exportedAt: '2026-05-08T12:00:00.000Z',
+        data: {
+            accounts: [{id: 1, name: 'Main', type: 'BANK', currency: 'CAD'}],
+            categories: [],
+            budgetTargets: [],
+            recurringTemplates: [],
+            transactions: [],
+            taxProfiles: [],
+            financialGoals: [],
+            projectionScenarios: [],
+            projectionSettings: null,
+            importBackup: null,
+        },
+    }, null, 2)
+}
+
+function flipBase64Byte(value) {
+    const buffer = Buffer.from(value, 'base64')
+    buffer[0] = buffer[0] ^ 0xff
+    return buffer.toString('base64')
+}
+
+describe('backup encryption primitives', () => {
+    it('encrypts and decrypts a backup JSON roundtrip', () => {
+        const {
+            ENCRYPTED_BACKUP_KIND,
+            ENCRYPTED_BACKUP_VERSION,
+            decryptBackupJson,
+            encryptBackupJson,
+            serializeEncryptedBackup,
+            parseEncryptedBackup,
+        } = loadBackupEncryption()
+        const backupJson = sampleBackupJson()
+
+        const envelope = encryptBackupJson(backupJson, 'correct horse battery staple', {
+            now: () => new Date('2026-05-08T12:00:00.000Z'),
+            metadata: {source: 'unit-test', backupVersion: 6},
+        })
+
+        expect(envelope).toMatchObject({
+            kind: ENCRYPTED_BACKUP_KIND,
+            version: ENCRYPTED_BACKUP_VERSION,
+            cipher: 'aes-256-gcm',
+            createdAt: '2026-05-08T12:00:00.000Z',
+            metadata: expect.objectContaining({
+                contentType: 'application/json',
+                purpose: 'local-backup-export',
+                source: 'unit-test',
+                backupVersion: 6,
+            }),
+        })
+        expect(envelope.ciphertext).not.toContain('Main')
+        expect(JSON.stringify(envelope)).not.toContain('correct horse battery staple')
+
+        const serialized = serializeEncryptedBackup(envelope)
+        const parsed = parseEncryptedBackup(serialized)
+        const decrypted = decryptBackupJson(parsed, 'correct horse battery staple')
+
+        expect(JSON.parse(decrypted)).toEqual(JSON.parse(backupJson))
+    })
+
+    it('fails cleanly when the password is wrong', () => {
+        const {
+            BACKUP_ENCRYPTION_ERROR_CODES,
+            decryptBackupJson,
+            encryptBackupJson,
+        } = loadBackupEncryption()
+        const envelope = encryptBackupJson(sampleBackupJson(), 'right-password')
+
+        expect(() => decryptBackupJson(envelope, 'wrong-password'))
+            .toThrow(expect.objectContaining({
+                code: BACKUP_ENCRYPTION_ERROR_CODES.WRONG_PASSWORD,
+            }))
+    })
+
+    it('detects modified encrypted content', () => {
+        const {
+            BACKUP_ENCRYPTION_ERROR_CODES,
+            decryptBackupJson,
+            encryptBackupJson,
+        } = loadBackupEncryption()
+        const envelope = encryptBackupJson(sampleBackupJson(), 'right-password')
+        const tampered = {
+            ...envelope,
+            ciphertext: flipBase64Byte(envelope.ciphertext),
+        }
+
+        expect(() => decryptBackupJson(tampered, 'right-password'))
+            .toThrow(expect.objectContaining({
+                code: BACKUP_ENCRYPTION_ERROR_CODES.CORRUPTED_CIPHERTEXT,
+            }))
+    })
+
+    it('rejects unknown encrypted backup versions', () => {
+        const {
+            BACKUP_ENCRYPTION_ERROR_CODES,
+            decryptBackupJson,
+            encryptBackupJson,
+        } = loadBackupEncryption()
+        const envelope = encryptBackupJson(sampleBackupJson(), 'password')
+
+        expect(() => decryptBackupJson({...envelope, version: 999}, 'password'))
+            .toThrow(expect.objectContaining({
+                code: BACKUP_ENCRYPTION_ERROR_CODES.UNSUPPORTED_ENCRYPTION_VERSION,
+            }))
+    })
+
+    it('uses different salt, nonce and ciphertext for two identical exports', () => {
+        const {encryptBackupJson} = loadBackupEncryption()
+        const backupJson = sampleBackupJson()
+        const first = encryptBackupJson(backupJson, 'same-password', {
+            now: () => new Date('2026-05-08T12:00:00.000Z'),
+        })
+        const second = encryptBackupJson(backupJson, 'same-password', {
+            now: () => new Date('2026-05-08T12:00:00.000Z'),
+        })
+
+        expect(first.salt).not.toBe(second.salt)
+        expect(first.nonce).not.toBe(second.nonce)
+        expect(first.ciphertext).not.toBe(second.ciphertext)
+    })
+
+    it('rejects non-backup JSON before encryption', () => {
+        const {
+            BACKUP_ENCRYPTION_ERROR_CODES,
+            encryptBackupJson,
+        } = loadBackupEncryption()
+
+        expect(() => encryptBackupJson('not-json', 'password'))
+            .toThrow(expect.objectContaining({
+                code: BACKUP_ENCRYPTION_ERROR_CODES.INVALID_INPUT,
+            }))
+    })
+})


### PR DESCRIPTION
## Summary

- add `electron/security/backupEncryption.js` for local backup envelope creation and recovery
- add a versioned envelope format with random salt/nonce fields, encrypted content, validation fields, timestamp and minimal metadata
- add structured errors for invalid files, bad credentials, unsupported versions and modified payloads
- document the envelope in `docs/backup-format.md`
- add targeted unit tests in `src/test/electron/backupEncryption.test.js`

Closes #88.

## Testing

- Not run locally in this environment.
- Added targeted unit tests.