### PR TITLE
restore: add dry-run validation and recovery backup

### DIFF
--- a/src/components/ImportReviewDialog.vue
+++ b/src/components/ImportReviewDialog.vue
@@ -7,7 +7,9 @@ defineProps<{
   subtitle?: string
   lines: string[]
   warnings?: string[]
+  blockingErrors?: string[]
   confirmLabel: string
+  confirmDisabled?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -44,7 +46,23 @@ const {t} = useI18n()
         </div>
       </div>
 
+      <div v-if="blockingErrors && blockingErrors.length" class="mt-5 space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.18em] text-rose-500">
+          Erreurs bloquantes
+        </p>
+        <div
+            v-for="error in blockingErrors"
+            :key="error"
+            class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-200"
+        >
+          {{ error }}
+        </div>
+      </div>
+
       <div v-if="warnings && warnings.length" class="mt-5 space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.18em] text-amber-500">
+          Warnings
+        </p>
         <div
             v-for="warning in warnings"
             :key="warning"
@@ -58,7 +76,7 @@ const {t} = useI18n()
         <button class="ghost-btn" @click="emit('close')">
           {{ t('common.cancel') }}
         </button>
-        <button class="primary-btn" @click="emit('confirm')">
+        <button class="primary-btn disabled:cursor-not-allowed disabled:opacity-50" :disabled="confirmDisabled" @click="emit('confirm')">
           {{ confirmLabel }}
         </button>
       </div>

--- a/src/composables/useJsonBackup.ts
+++ b/src/composables/useJsonBackup.ts
@@ -10,7 +10,11 @@ import type {
     Transaction,
 } from '../types/budget'
 import {tr} from '../i18n'
-import {validateBackupSnapshot, type BackupValidationResult} from '../utils/importValidation'
+import {
+    createRestoreDryRunReport,
+    markRecoveryBackupCreated,
+    type RestoreDryRunReport,
+} from '../utils/restoreDryRun'
 import {
     createBudgetBackupSnapshotWithGoals,
     type BudgetBackupFinancialGoal,
@@ -45,10 +49,6 @@ const JSON_BACKUP_FILTERS = [{name: 'JSON', extensions: ['json']}]
 
 function absAmount(value: number | null | undefined) {
     return Math.abs(value ?? 0)
-}
-
-function firstValidationError(validation: BackupValidationResult) {
-    return validation.warnings[0] || tr('notices.jsonInvalid')
 }
 
 function asLegacyBackupSnapshot(snapshot: unknown): BudgetBackupSnapshot {
@@ -186,13 +186,13 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
     const restorePreviewOpen = ref(false)
     const restorePreviewPath = ref<string | null>(null)
     const restorePreviewSnapshot = ref<BudgetBackupWithImportDataSnapshot | null>(null)
-    const restorePreviewValidation = ref<BackupValidationResult | null>(null)
+    const restorePreviewReport = ref<RestoreDryRunReport | null>(null)
 
     function closeRestorePreview() {
         restorePreviewOpen.value = false
         restorePreviewPath.value = null
         restorePreviewSnapshot.value = null
-        restorePreviewValidation.value = null
+        restorePreviewReport.value = null
     }
 
     async function createCanonicalBackupContent() {
@@ -213,6 +213,17 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
         )
         const snapshot = createBudgetBackupSnapshotWithImportData(goalsSnapshot, importData)
         return serializeBudgetBackupWithImportData(snapshot)
+    }
+
+    function currentRestoreState() {
+        return {
+            accounts: options.accounts.value,
+            categories: options.categories.value,
+            budgetTargets: options.budgetTargets.value,
+            recurringTemplates: options.recurringTemplates.value,
+            transactions: options.transactions.value,
+            taxProfiles: options.taxProfiles?.value || [],
+        }
     }
 
     function requestEncryptedExportPassword() {
@@ -282,12 +293,14 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
 
     function prepareRestorePreview(content: string, filePath: string | null) {
         const snapshot = parseBudgetBackupWithImportData(content)
-        const validation = validateBackupSnapshot(asLegacyBackupSnapshot(snapshot))
-        if (!validation.ok) throw new Error(firstValidationError(validation))
+        const report = createRestoreDryRunReport(snapshot, currentRestoreState())
         restorePreviewSnapshot.value = snapshot
-        restorePreviewValidation.value = validation
+        restorePreviewReport.value = report
         restorePreviewPath.value = filePath
         restorePreviewOpen.value = true
+        if (!report.canApply) {
+            options.showNotice('error', 'Le dry-run de restauration a détecté des erreurs bloquantes. Aucune donnée n’a été modifiée.')
+        }
     }
 
     async function beginRestoreBackupJson() {
@@ -375,13 +388,35 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
         }
     }
 
+    async function createPreRestoreBackup() {
+        const content = await createCanonicalBackupContent()
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').replace('Z', '')
+        const result = await window.file.saveText({
+            title: 'Sauvegarde automatique avant restauration',
+            defaultPath: `pre-restore-backup-${timestamp}.json`,
+            content,
+            filters: JSON_BACKUP_FILTERS,
+        })
+        if (!result || result.canceled || !result.filePath) {
+            throw new Error('Restauration annulée : la sauvegarde pré-restore doit être créée avant toute modification.')
+        }
+        return result.filePath
+    }
+
     async function confirmRestoreBackupJson() {
         if (!restorePreviewSnapshot.value) return
         try {
             const snapshot = restorePreviewSnapshot.value
+            const report = createRestoreDryRunReport(snapshot, currentRestoreState())
+            restorePreviewReport.value = report
+            if (!report.canApply) {
+                throw new Error('Restauration bloquée : corrige les erreurs du dry-run avant de restaurer.')
+            }
+            const accepted = window.confirm('La restauration va remplacer toutes les données actuelles. Une sauvegarde pré-restore sera créée avant modification. Continuer ?')
+            if (!accepted) return
+            const recoveryPath = await createPreRestoreBackup()
+            restorePreviewReport.value = markRecoveryBackupCreated(report, recoveryPath)
             const legacySnapshot = asLegacyBackupSnapshot(snapshot)
-            const validation = validateBackupSnapshot(legacySnapshot)
-            if (!validation.ok) throw new Error(firstValidationError(validation))
             await replaceAllData()
             const accountIdMap = new Map<number, number>()
             const categoryIdMap = new Map<number, number>()
@@ -412,7 +447,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
             await restoreImportBackupData(importBackup)
             await options.refreshAllData()
             closeRestorePreview()
-            options.showNotice('success', tr('notices.jsonRestored'))
+            options.showNotice('success', `${tr('notices.jsonRestored')} Sauvegarde pré-restore : ${recoveryPath}`)
         } catch (error) {
             options.showNotice('error', error instanceof Error ? error.message : tr('notices.jsonRestoreFailed'))
         }
@@ -427,6 +462,7 @@ export function useJsonBackup(options: UseJsonBackupOptions) {
         closeRestorePreview,
         restorePreviewOpen,
         restorePreviewPath,
-        restorePreviewValidation,
+        restorePreviewReport,
+        restorePreviewValidation: restorePreviewReport,
     }
 }

--- a/src/test/composables/useJsonBackup.restore.test.ts
+++ b/src/test/composables/useJsonBackup.restore.test.ts
@@ -172,9 +172,10 @@ function installBridgeMocks() {
     let transactionId = 300
 
     ;(window as any).file = {
-        saveText: vi.fn().mockResolvedValue({canceled: false}),
+        saveText: vi.fn().mockResolvedValue({canceled: false, filePath: '/tmp/pre-restore-backup.json'}),
         openText: vi.fn(),
     }
+    ;(window as any).confirm = vi.fn().mockReturnValue(true)
 
     ;(window as any).db = {
         transaction: {
@@ -275,7 +276,7 @@ describe('useJsonBackup restore flows', () => {
         expect(showNotice).toHaveBeenCalledWith('error', expect.stringContaining('JSON'))
     })
 
-    it('opens and closes a valid restore preview', async () => {
+    it('opens and closes a valid restore preview without writing data', async () => {
         const {backup} = createHarness()
         ;(window as any).file.openText.mockResolvedValueOnce({
             canceled: false,
@@ -290,6 +291,8 @@ describe('useJsonBackup restore flows', () => {
         expect(backup.restorePreviewValidation.value?.ok).toBe(true)
         expect(backup.restorePreviewValidation.value?.counts.accounts).toBe(2)
         expect(backup.restorePreviewValidation.value?.counts.taxProfiles).toBe(1)
+        expect((window as any).db.account.delete).not.toHaveBeenCalled()
+        expect((window as any).db.account.create).not.toHaveBeenCalled()
 
         backup.closeRestorePreview()
 
@@ -298,7 +301,7 @@ describe('useJsonBackup restore flows', () => {
         expect(backup.restorePreviewValidation.value).toBeNull()
     })
 
-    it('replaces existing data and restores all supported backup entities', async () => {
+    it('creates a pre-restore backup before replacing existing data', async () => {
         const {backup, refreshAllData, showNotice} = createHarness()
         ;(window as any).file.openText.mockResolvedValueOnce({
             canceled: false,
@@ -308,6 +311,15 @@ describe('useJsonBackup restore flows', () => {
 
         await backup.beginRestoreBackupJson()
         await backup.confirmRestoreBackupJson()
+
+        expect((window as any).confirm).toHaveBeenCalledWith(expect.stringContaining('sauvegarde pré-restore'))
+        expect((window as any).file.saveText).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'Sauvegarde automatique avant restauration',
+            defaultPath: expect.stringContaining('pre-restore-backup-'),
+            filters: [{name: 'JSON', extensions: ['json']}],
+        }))
+        expect((window as any).file.saveText.mock.invocationCallOrder[0])
+            .toBeLessThan((window as any).db.transaction.delete.mock.invocationCallOrder[0])
 
         expect((window as any).db.transaction.delete).toHaveBeenCalledWith(905)
         expect((window as any).db.recurringTemplate.delete).toHaveBeenCalledWith(904)
@@ -382,10 +394,50 @@ describe('useJsonBackup restore flows', () => {
         }))
         expect(refreshAllData).toHaveBeenCalledTimes(1)
         expect(backup.restorePreviewOpen.value).toBe(false)
-        expect(showNotice).toHaveBeenCalledWith('success', expect.any(String))
+        expect(showNotice).toHaveBeenCalledWith('success', expect.stringContaining('Sauvegarde pré-restore'))
     })
 
-    it('reports restore failures without closing the preview', async () => {
+    it('blocks restore with dry-run errors before confirmation or writes', async () => {
+        const {backup, refreshAllData, showNotice} = createHarness()
+        const broken = validSnapshot()
+        broken.data.transactions[0].accountId = 999
+        ;(window as any).file.openText.mockResolvedValueOnce({
+            canceled: false,
+            filePath: '/tmp/broken-backup.json',
+            content: JSON.stringify(broken),
+        })
+
+        await backup.beginRestoreBackupJson()
+        await backup.confirmRestoreBackupJson()
+
+        expect(backup.restorePreviewOpen.value).toBe(true)
+        expect(backup.restorePreviewValidation.value?.canApply).toBe(false)
+        expect((window as any).confirm).not.toHaveBeenCalled()
+        expect((window as any).file.saveText).not.toHaveBeenCalled()
+        expect((window as any).db.account.delete).not.toHaveBeenCalled()
+        expect(refreshAllData).not.toHaveBeenCalled()
+        expect(showNotice).toHaveBeenCalledWith('error', expect.stringContaining('erreurs bloquantes'))
+    })
+
+    it('does not modify data when the pre-restore backup is canceled', async () => {
+        const {backup, refreshAllData, showNotice} = createHarness()
+        ;(window as any).file.saveText.mockResolvedValueOnce({canceled: true, filePath: null})
+        ;(window as any).file.openText.mockResolvedValueOnce({
+            canceled: false,
+            filePath: '/tmp/budget-backup.json',
+            content: JSON.stringify(validSnapshot()),
+        })
+
+        await backup.beginRestoreBackupJson()
+        await backup.confirmRestoreBackupJson()
+
+        expect((window as any).db.account.delete).not.toHaveBeenCalled()
+        expect((window as any).db.account.create).not.toHaveBeenCalled()
+        expect(refreshAllData).not.toHaveBeenCalled()
+        expect(showNotice).toHaveBeenCalledWith('error', expect.stringContaining('sauvegarde pré-restore'))
+    })
+
+    it('reports restore failures without closing the preview after the recovery backup exists', async () => {
         const {backup, refreshAllData, showNotice} = createHarness()
         ;(window as any).db.account.create.mockRejectedValueOnce(new Error('create failed'))
         ;(window as any).file.openText.mockResolvedValueOnce({
@@ -397,6 +449,9 @@ describe('useJsonBackup restore flows', () => {
         await backup.beginRestoreBackupJson()
         await backup.confirmRestoreBackupJson()
 
+        expect((window as any).file.saveText).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'Sauvegarde automatique avant restauration',
+        }))
         expect(refreshAllData).not.toHaveBeenCalled()
         expect(backup.restorePreviewOpen.value).toBe(true)
         expect(showNotice).toHaveBeenCalledWith('error', 'create failed')

--- a/src/test/utils/restoreDryRun.test.ts
+++ b/src/test/utils/restoreDryRun.test.ts
@@ -1,0 +1,215 @@
+import {describe, expect, it} from 'vitest'
+import {createRestoreDryRunReport, markRecoveryBackupCreated} from '../../utils/restoreDryRun'
+import type {BudgetBackupWithImportDataSnapshot} from '../../utils/importJsonBackup'
+
+function validSnapshot(overrides: Partial<BudgetBackupWithImportDataSnapshot> = {}): BudgetBackupWithImportDataSnapshot {
+    const snapshot: BudgetBackupWithImportDataSnapshot = {
+        kind: 'budget-backup',
+        version: 6,
+        exportedAt: '2026-05-08T12:00:00.000Z',
+        data: {
+            accounts: [
+                {
+                    id: 1,
+                    name: 'Main',
+                    type: 'BANK',
+                    currency: 'CAD',
+                    description: null,
+                    institutionCountry: 'CA',
+                    institutionRegion: 'QC',
+                    taxReportingType: 'BANK',
+                    openedAt: null,
+                    closedAt: null,
+                },
+            ],
+            categories: [
+                {id: 10, name: 'Groceries', kind: 'EXPENSE', color: null, description: null},
+            ],
+            budgetTargets: [
+                {
+                    id: 20,
+                    name: 'Food',
+                    amount: 500,
+                    period: 'MONTHLY',
+                    startDate: '2026-05-01',
+                    endDate: null,
+                    currency: 'CAD',
+                    isActive: true,
+                    note: null,
+                    categoryId: 10,
+                },
+            ],
+            recurringTemplates: [],
+            transactions: [
+                {
+                    id: 100,
+                    label: 'Groceries',
+                    amount: 42,
+                    sourceAmount: 42,
+                    sourceCurrency: 'CAD',
+                    conversionMode: 'NONE',
+                    exchangeRate: 1,
+                    exchangeProvider: 'ACCOUNT',
+                    exchangeDate: '2026-05-08',
+                    kind: 'EXPENSE',
+                    date: '2026-05-08',
+                    note: null,
+                    taxCategory: null,
+                    taxSourceCountry: null,
+                    taxSourceRegion: null,
+                    taxTreatment: 'UNKNOWN',
+                    taxWithheldAmount: null,
+                    taxWithheldCurrency: null,
+                    taxWithheldCountry: null,
+                    taxDocumentRef: null,
+                    accountId: 1,
+                    categoryId: 10,
+                    transferGroup: null,
+                    transferDirection: null,
+                    transferPeerAccountId: null,
+                },
+            ],
+            taxProfiles: [],
+            financialGoals: [
+                {
+                    id: 300,
+                    name: 'Emergency fund',
+                    type: 'SAVINGS',
+                    targetAmount: 10000,
+                    currency: 'CAD',
+                    targetDate: null,
+                    startingAmount: null,
+                    status: 'ACTIVE',
+                    priority: null,
+                    notes: null,
+                    trackedAssetId: null,
+                    trackedPortfolioId: null,
+                    trackedLiabilityId: null,
+                    baselineNetWorthSnapshotId: null,
+                },
+            ],
+            projectionScenarios: [
+                {
+                    id: 400,
+                    name: 'Base',
+                    kind: 'BASE',
+                    description: null,
+                    monthlySurplus: 500,
+                    annualGrowthRate: null,
+                    annualInflationRate: null,
+                    horizonMonths: 24,
+                    currency: 'CAD',
+                    isDefault: true,
+                    isActive: true,
+                    notes: null,
+                },
+            ],
+            projectionSettings: null,
+            importBackup: {
+                schemaVersion: 1,
+                documentation: {included: [], excluded: [], notes: []},
+                mappingTemplates: [],
+                importSources: [],
+                importHistory: [],
+                metadata: {
+                    exportedAt: '2026-05-08T12:00:00.000Z',
+                    auditOnlyRestore: true,
+                    financialDataNotRestoredFromImportHistory: true,
+                },
+            },
+        },
+    }
+
+    return {...snapshot, ...overrides, data: {...snapshot.data, ...(overrides.data || {})}}
+}
+
+describe('restore dry-run report', () => {
+    it('summarizes a valid restore without mutating the current state', () => {
+        const current = {
+            accounts: [{id: 999}],
+            categories: [{id: 998}],
+            budgetTargets: [{id: 997}],
+            recurringTemplates: [],
+            transactions: [{id: 996}],
+            taxProfiles: [],
+        }
+        const snapshot = validSnapshot()
+        const before = JSON.stringify(current)
+
+        const report = createRestoreDryRunReport(snapshot, current)
+
+        expect(JSON.stringify(current)).toBe(before)
+        expect(report.ok).toBe(true)
+        expect(report.canApply).toBe(true)
+        expect(report.counts.accountsToCreate).toBe(1)
+        expect(report.counts.categoriesToCreate).toBe(1)
+        expect(report.counts.transactionsToCreate).toBe(1)
+        expect(report.counts.financialGoalsToCreate).toBe(1)
+        expect(report.counts.projectionScenariosToCreate).toBe(1)
+        expect(report.counts.existingAccountsToReplace).toBe(1)
+        expect(report.recovery).toMatchObject({
+            preRestoreBackupRequired: true,
+            createdBeforeWrite: false,
+            path: null,
+        })
+    })
+
+    it('blocks duplicated ids, invalid currencies, invalid dates, invalid amounts and broken references', () => {
+        const snapshot = validSnapshot({
+            data: {
+                ...validSnapshot().data,
+                accounts: [
+                    {...validSnapshot().data.accounts[0], id: 1, currency: 'CAD'},
+                    {...validSnapshot().data.accounts[0], id: 1, name: 'Duplicate', currency: 'CAD'},
+                ],
+                budgetTargets: [
+                    {...validSnapshot().data.budgetTargets[0], amount: 0, categoryId: 999, startDate: 'bad-date'},
+                ],
+                transactions: [
+                    {...validSnapshot().data.transactions[0], amount: -1, accountId: 999, date: 'not-a-date'},
+                ],
+                financialGoals: [
+                    {...validSnapshot().data.financialGoals[0], currency: 'CA', targetAmount: 0},
+                ],
+            },
+        })
+
+        const report = createRestoreDryRunReport(snapshot)
+
+        expect(report.ok).toBe(false)
+        expect(report.canApply).toBe(false)
+        expect(report.blockingErrors.join('\n')).toContain('identifiant dupliqué')
+        expect(report.blockingErrors.join('\n')).toContain('catégorie absente')
+        expect(report.blockingErrors.join('\n')).toContain('montant non positif')
+        expect(report.blockingErrors.join('\n')).toContain('date de début invalide')
+        expect(report.blockingErrors.join('\n')).toContain('compte absent')
+        expect(report.blockingErrors.join('\n')).toContain('devise invalide')
+        expect(report.warnings.some((warning) => warning.startsWith('Erreur bloquante :'))).toBe(true)
+    })
+
+    it('keeps warnings visible without blocking a restore', () => {
+        const snapshot = validSnapshot({
+            data: {
+                ...validSnapshot().data,
+                accounts: [{...validSnapshot().data.accounts[0], name: ''}],
+            },
+        })
+
+        const report = createRestoreDryRunReport(snapshot)
+
+        expect(report.canApply).toBe(true)
+        expect(report.warnings).toContain('Un compte a un nom vide.')
+    })
+
+    it('marks a pre-restore recovery backup as created', () => {
+        const report = createRestoreDryRunReport(validSnapshot())
+        const updated = markRecoveryBackupCreated(report, '/tmp/pre-restore.json')
+
+        expect(updated.recovery).toMatchObject({
+            preRestoreBackupRequired: true,
+            createdBeforeWrite: true,
+            path: '/tmp/pre-restore.json',
+        })
+        expect(report.recovery.createdBeforeWrite).toBe(false)
+    })
+})

--- a/src/utils/restoreDryRun.ts
+++ b/src/utils/restoreDryRun.ts
@@ -10,6 +10,12 @@ export interface RestoreDryRunReport {
         exportedAt: string | null
     }
     counts: {
+        accounts: number
+        categories: number
+        budgetTargets: number
+        recurringTemplates: number
+        transactions: number
+        taxProfiles: number
         accountsToCreate: number
         categoriesToCreate: number
         budgetTargetsToCreate: number
@@ -284,14 +290,26 @@ function validateImportBackup(snapshot: BudgetBackupWithImportDataSnapshot, erro
 
 function buildCounts(snapshot: BudgetBackupWithImportDataSnapshot, current: RestoreDryRunCurrentState): RestoreDryRunReport['counts'] {
     const importBackup = snapshot.data.importBackup
+    const accountsToCreate = snapshot.data.accounts.length
+    const categoriesToCreate = snapshot.data.categories.length
+    const budgetTargetsToCreate = snapshot.data.budgetTargets.length
+    const recurringTemplatesToCreate = snapshot.data.recurringTemplates.length
+    const transactionsToCreate = snapshot.data.transactions.length
+    const taxProfilesToCreate = (snapshot.data.taxProfiles || []).length
 
     return {
-        accountsToCreate: snapshot.data.accounts.length,
-        categoriesToCreate: snapshot.data.categories.length,
-        budgetTargetsToCreate: snapshot.data.budgetTargets.length,
-        recurringTemplatesToCreate: snapshot.data.recurringTemplates.length,
-        transactionsToCreate: snapshot.data.transactions.length,
-        taxProfilesToCreate: (snapshot.data.taxProfiles || []).length,
+        accounts: accountsToCreate,
+        categories: categoriesToCreate,
+        budgetTargets: budgetTargetsToCreate,
+        recurringTemplates: recurringTemplatesToCreate,
+        transactions: transactionsToCreate,
+        taxProfiles: taxProfilesToCreate,
+        accountsToCreate,
+        categoriesToCreate,
+        budgetTargetsToCreate,
+        recurringTemplatesToCreate,
+        transactionsToCreate,
+        taxProfilesToCreate,
         financialGoalsToCreate: (snapshot.data.financialGoals || []).length,
         projectionScenariosToCreate: (snapshot.data.projectionScenarios || []).length,
         importMappingTemplatesToRestore: importBackup?.mappingTemplates?.length || 0,
@@ -350,7 +368,11 @@ export function createRestoreDryRunReport(
         },
         counts: buildCounts(snapshot, current),
         ignoredItems: uniqueIgnoredItems,
-        warnings: uniqueWarnings,
+        warnings: [
+            ...uniqueBlockingErrors.map((error) => `Erreur bloquante : ${error}`),
+            ...uniqueWarnings,
+            ...uniqueIgnoredItems.map((item) => `Élément ignoré : ${item}`),
+        ],
         blockingErrors: uniqueBlockingErrors,
         recovery: {
             preRestoreBackupRequired: true,

--- a/src/utils/restoreDryRun.ts
+++ b/src/utils/restoreDryRun.ts
@@ -1,0 +1,372 @@
+import type {BudgetBackupSnapshot, BudgetBackupTransaction} from '../types/budget'
+import type {BudgetBackupWithImportDataSnapshot} from './importJsonBackup'
+
+export interface RestoreDryRunReport {
+    ok: boolean
+    canApply: boolean
+    source: {
+        kind: string
+        version: number
+        exportedAt: string | null
+    }
+    counts: {
+        accountsToCreate: number
+        categoriesToCreate: number
+        budgetTargetsToCreate: number
+        recurringTemplatesToCreate: number
+        transactionsToCreate: number
+        taxProfilesToCreate: number
+        financialGoalsToCreate: number
+        projectionScenariosToCreate: number
+        importMappingTemplatesToRestore: number
+        importHistoryItemsToRestore: number
+        existingAccountsToReplace: number
+        existingCategoriesToReplace: number
+        existingBudgetTargetsToReplace: number
+        existingRecurringTemplatesToReplace: number
+        existingTransactionsToReplace: number
+        existingTaxProfilesToReplace: number
+    }
+    ignoredItems: string[]
+    warnings: string[]
+    blockingErrors: string[]
+    recovery: {
+        preRestoreBackupRequired: true
+        createdBeforeWrite: boolean
+        path: string | null
+    }
+}
+
+export interface RestoreDryRunCurrentState {
+    accounts?: unknown[]
+    categories?: unknown[]
+    budgetTargets?: unknown[]
+    recurringTemplates?: unknown[]
+    transactions?: unknown[]
+    taxProfiles?: unknown[]
+}
+
+const SUPPORTED_KIND = 'budget-backup'
+const SUPPORTED_VERSIONS = new Set([2, 3, 4, 5, 6])
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
+const CURRENCY_CODE = /^[A-Z]{3}$/
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasValidDate(value: string | null | undefined, dateOnly = false) {
+    if (value == null || value === '') return true
+    if (dateOnly && !ISO_DATE_ONLY.test(value)) return false
+    return !Number.isNaN(Date.parse(value))
+}
+
+function isValidCurrency(value: string | null | undefined) {
+    return typeof value === 'string' && CURRENCY_CODE.test(value.trim().toUpperCase())
+}
+
+function addDuplicateIdErrors(rows: Array<{id: number; name?: string; label?: string}>, entityLabel: string, errors: string[]) {
+    const seen = new Map<number, string>()
+
+    for (const row of rows) {
+        const label = row.name || row.label || `#${row.id}`
+        const existing = seen.get(row.id)
+        if (existing) {
+            errors.push(`${entityLabel} contient un identifiant dupliqué (${row.id}) : ${existing} / ${label}.`)
+        } else {
+            seen.set(row.id, label)
+        }
+    }
+}
+
+function addDuplicateStringIdErrors(rows: Array<{id: string; name?: string; label?: string}>, entityLabel: string, errors: string[]) {
+    const seen = new Map<string, string>()
+
+    for (const row of rows) {
+        const id = String(row.id)
+        const label = row.name || row.label || id
+        const existing = seen.get(id)
+        if (existing) {
+            errors.push(`${entityLabel} contient un identifiant dupliqué (${id}) : ${existing} / ${label}.`)
+        } else {
+            seen.set(id, label)
+        }
+    }
+}
+
+function hasSection(snapshot: BudgetBackupSnapshot, key: keyof BudgetBackupSnapshot['data']) {
+    return Array.isArray((snapshot.data as Record<string, unknown>)[key as string])
+}
+
+function validateRequiredSections(snapshot: BudgetBackupSnapshot, errors: string[]) {
+    const requiredSections: Array<keyof BudgetBackupSnapshot['data']> = [
+        'accounts',
+        'categories',
+        'budgetTargets',
+        'recurringTemplates',
+        'transactions',
+        'taxProfiles',
+    ]
+
+    for (const section of requiredSections) {
+        if (!hasSection(snapshot, section)) {
+            errors.push(`Section data.${String(section)} absente ou invalide.`)
+        }
+    }
+}
+
+function validateRoot(snapshot: BudgetBackupWithImportDataSnapshot, errors: string[]) {
+    if (snapshot.kind !== SUPPORTED_KIND) {
+        errors.push(`Type de backup invalide (${snapshot.kind || 'inconnu'}).`)
+    }
+
+    if (!SUPPORTED_VERSIONS.has(Number(snapshot.version))) {
+        errors.push(`Version de backup JSON non supportée (${snapshot.version}).`)
+    }
+
+    if (!snapshot.exportedAt || Number.isNaN(Date.parse(snapshot.exportedAt))) {
+        errors.push('Le backup doit contenir une date exportedAt valide.')
+    }
+}
+
+function validateAccounts(snapshot: BudgetBackupSnapshot, errors: string[], warnings: string[]) {
+    for (const account of snapshot.data.accounts) {
+        if (!account.name.trim()) warnings.push('Un compte a un nom vide.')
+        if (!isValidCurrency(account.currency)) errors.push(`Compte "${account.name || account.id}" avec devise invalide (${account.currency || 'vide'}).`)
+        if (!hasValidDate(account.openedAt)) errors.push(`Compte "${account.name || account.id}" avec date d’ouverture invalide.`)
+        if (!hasValidDate(account.closedAt)) errors.push(`Compte "${account.name || account.id}" avec date de fermeture invalide.`)
+        if (account.openedAt && account.closedAt && Date.parse(account.closedAt) < Date.parse(account.openedAt)) {
+            warnings.push(`Compte "${account.name}" : la date de fermeture précède la date d’ouverture.`)
+        }
+    }
+}
+
+function validateCategories(snapshot: BudgetBackupSnapshot, warnings: string[]) {
+    for (const category of snapshot.data.categories) {
+        if (!category.name.trim()) warnings.push('Une catégorie a un nom vide.')
+    }
+}
+
+function validateBudgetTargets(snapshot: BudgetBackupSnapshot, categoryIds: Set<number>, errors: string[], warnings: string[]) {
+    for (const budgetTarget of snapshot.data.budgetTargets) {
+        if (!budgetTarget.name.trim()) warnings.push('Un budget a un nom vide.')
+        if (!categoryIds.has(budgetTarget.categoryId)) errors.push(`Budget "${budgetTarget.name}" référence une catégorie absente (${budgetTarget.categoryId}).`)
+        if (!(budgetTarget.amount > 0)) errors.push(`Budget "${budgetTarget.name}" avec montant non positif.`)
+        if (!isValidCurrency(budgetTarget.currency)) errors.push(`Budget "${budgetTarget.name}" avec devise invalide (${budgetTarget.currency || 'vide'}).`)
+        if (!hasValidDate(budgetTarget.startDate, true)) errors.push(`Budget "${budgetTarget.name}" avec date de début invalide.`)
+        if (!hasValidDate(budgetTarget.endDate, true)) errors.push(`Budget "${budgetTarget.name}" avec date de fin invalide.`)
+    }
+}
+
+function validateRecurringTemplates(snapshot: BudgetBackupSnapshot, accountIds: Set<number>, categoryIds: Set<number>, errors: string[], warnings: string[]) {
+    for (const template of snapshot.data.recurringTemplates) {
+        if (!template.label.trim()) warnings.push('Une récurrence a un libellé vide.')
+        if (!accountIds.has(template.accountId)) errors.push(`Récurrence "${template.label}" référence un compte absent (${template.accountId}).`)
+        if (template.categoryId != null && !categoryIds.has(template.categoryId)) errors.push(`Récurrence "${template.label}" référence une catégorie absente (${template.categoryId}).`)
+        if (!(template.sourceAmount > 0)) errors.push(`Récurrence "${template.label}" avec montant source non positif.`)
+        if (template.accountAmount != null && !(template.accountAmount > 0)) errors.push(`Récurrence "${template.label}" avec montant comptabilisé non positif.`)
+        if (!isValidCurrency(template.sourceCurrency)) errors.push(`Récurrence "${template.label}" avec devise source invalide (${template.sourceCurrency || 'vide'}).`)
+        if (!hasValidDate(template.startDate, true)) errors.push(`Récurrence "${template.label}" avec date de début invalide.`)
+        if (!hasValidDate(template.nextOccurrenceDate, true)) errors.push(`Récurrence "${template.label}" avec prochaine occurrence invalide.`)
+        if (!hasValidDate(template.endDate, true)) errors.push(`Récurrence "${template.label}" avec date de fin invalide.`)
+    }
+}
+
+function validateTransferGroups(transactions: BudgetBackupTransaction[], accountIds: Set<number>, errors: string[], warnings: string[]) {
+    const transferGroups = new Map<string, BudgetBackupTransaction[]>()
+
+    for (const transaction of transactions) {
+        if (transaction.transferGroup) {
+            const rows = transferGroups.get(transaction.transferGroup) || []
+            rows.push(transaction)
+            transferGroups.set(transaction.transferGroup, rows)
+        }
+    }
+
+    for (const [group, rows] of transferGroups.entries()) {
+        const outgoing = rows.filter((transaction) => transaction.transferDirection === 'OUT')
+        const incoming = rows.filter((transaction) => transaction.transferDirection === 'IN')
+
+        if (rows.length !== 2) {
+            errors.push(`Le transfert interne ${group} doit contenir exactement deux jambes.`)
+        } else if (outgoing.length !== 1 || incoming.length !== 1) {
+            errors.push(`Le transfert interne ${group} doit contenir une jambe OUT et une jambe IN.`)
+        } else if (
+            outgoing[0].accountId === incoming[0].accountId ||
+            outgoing[0].transferPeerAccountId !== incoming[0].accountId ||
+            incoming[0].transferPeerAccountId !== outgoing[0].accountId ||
+            !accountIds.has(outgoing[0].accountId) ||
+            !accountIds.has(incoming[0].accountId)
+        ) {
+            errors.push(`Le transfert interne ${group} est incohérent.`)
+        }
+
+        if (rows.some((transaction) => transaction.kind !== 'TRANSFER')) {
+            warnings.push(`Le groupe ${group} contient une ligne qui n’est pas marquée comme transfert.`)
+        }
+    }
+}
+
+function validateTransactions(snapshot: BudgetBackupSnapshot, accountIds: Set<number>, categoryIds: Set<number>, errors: string[], warnings: string[]) {
+    for (const transaction of snapshot.data.transactions) {
+        if (!transaction.label.trim()) warnings.push('Une transaction a un libellé vide.')
+        if (!accountIds.has(transaction.accountId)) errors.push(`Transaction "${transaction.label}" référence un compte absent (${transaction.accountId}).`)
+        if (transaction.categoryId != null && !categoryIds.has(transaction.categoryId)) errors.push(`Transaction "${transaction.label}" référence une catégorie absente (${transaction.categoryId}).`)
+        if (!(transaction.amount > 0)) errors.push(`Transaction "${transaction.label}" avec montant non positif.`)
+        if (transaction.sourceAmount != null && !(transaction.sourceAmount > 0)) errors.push(`Transaction "${transaction.label}" avec montant source non positif.`)
+        if (transaction.sourceCurrency != null && !isValidCurrency(transaction.sourceCurrency)) errors.push(`Transaction "${transaction.label}" avec devise source invalide (${transaction.sourceCurrency}).`)
+        if (!hasValidDate(transaction.date, true)) errors.push(`Transaction "${transaction.label}" avec date invalide.`)
+        if (!hasValidDate(transaction.exchangeDate, true)) errors.push(`Transaction "${transaction.label}" avec date de taux invalide.`)
+        if (transaction.transferPeerAccountId != null && !accountIds.has(transaction.transferPeerAccountId)) {
+            errors.push(`Transaction "${transaction.label}" référence un compte pair absent (${transaction.transferPeerAccountId}).`)
+        }
+        if (transaction.kind === 'TRANSFER' && transaction.categoryId != null) {
+            warnings.push(`Transaction "${transaction.label}" est un transfert mais porte une catégorie (${transaction.categoryId}).`)
+        }
+    }
+
+    validateTransferGroups(snapshot.data.transactions, accountIds, errors, warnings)
+}
+
+function validateTaxProfiles(snapshot: BudgetBackupSnapshot, errors: string[]) {
+    for (const profile of snapshot.data.taxProfiles || []) {
+        if (!(profile.year >= 1900 && profile.year <= 2200)) errors.push(`Profil fiscal ${profile.id} avec année invalide (${profile.year}).`)
+        if (!profile.residenceCountry.trim()) errors.push(`Profil fiscal ${profile.id} sans pays de résidence.`)
+        if (!isValidCurrency(profile.currency)) errors.push(`Profil fiscal ${profile.id} avec devise invalide (${profile.currency || 'vide'}).`)
+    }
+}
+
+function validateGoals(snapshot: BudgetBackupWithImportDataSnapshot, errors: string[], warnings: string[]) {
+    const goals = snapshot.data.financialGoals || []
+    const scenarios = snapshot.data.projectionScenarios || []
+
+    addDuplicateIdErrors(goals as Array<{id: number; name?: string}>, 'Objectifs', errors)
+    addDuplicateIdErrors(scenarios as Array<{id: number; name?: string}>, 'Scénarios', errors)
+
+    for (const goal of goals) {
+        if (!goal.name.trim()) warnings.push('Un objectif a un nom vide.')
+        if (!(goal.targetAmount > 0)) errors.push(`Objectif "${goal.name}" avec montant cible non positif.`)
+        if (!isValidCurrency(goal.currency)) errors.push(`Objectif "${goal.name}" avec devise invalide (${goal.currency || 'vide'}).`)
+        if (!hasValidDate(goal.targetDate, true)) errors.push(`Objectif "${goal.name}" avec date cible invalide.`)
+    }
+
+    for (const scenario of scenarios) {
+        if (!scenario.name.trim()) warnings.push('Un scénario a un nom vide.')
+        if (!isValidCurrency(scenario.currency)) errors.push(`Scénario "${scenario.name}" avec devise invalide (${scenario.currency || 'vide'}).`)
+        if (!(scenario.horizonMonths >= 1 && scenario.horizonMonths <= 1200)) errors.push(`Scénario "${scenario.name}" avec horizon invalide (${scenario.horizonMonths}).`)
+    }
+}
+
+function validateImportBackup(snapshot: BudgetBackupWithImportDataSnapshot, errors: string[], warnings: string[], ignoredItems: string[]) {
+    const importBackup = snapshot.data.importBackup
+    if (!importBackup) {
+        ignoredItems.push('Aucune donnée d’audit d’import à restaurer.')
+        return
+    }
+
+    addDuplicateStringIdErrors(importBackup.mappingTemplates || [], 'Templates de mapping import', errors)
+    addDuplicateStringIdErrors(importBackup.importHistory || [], 'Historique d’import', errors)
+
+    if (importBackup.metadata?.auditOnlyRestore !== true) {
+        errors.push('L’historique d’import doit rester en mode audit-only pour la restauration.')
+    }
+
+    for (const template of importBackup.mappingTemplates || []) {
+        if (isRecord(template) && String(template.id || '').startsWith('system:')) {
+            ignoredItems.push(`Template système ignoré : ${String(template.id)}.`)
+        }
+    }
+
+    if ((importBackup.importHistory || []).length) {
+        warnings.push('L’historique d’import sera restauré en audit-only ; il ne recréera pas de transactions financières.')
+    }
+}
+
+function buildCounts(snapshot: BudgetBackupWithImportDataSnapshot, current: RestoreDryRunCurrentState): RestoreDryRunReport['counts'] {
+    const importBackup = snapshot.data.importBackup
+
+    return {
+        accountsToCreate: snapshot.data.accounts.length,
+        categoriesToCreate: snapshot.data.categories.length,
+        budgetTargetsToCreate: snapshot.data.budgetTargets.length,
+        recurringTemplatesToCreate: snapshot.data.recurringTemplates.length,
+        transactionsToCreate: snapshot.data.transactions.length,
+        taxProfilesToCreate: (snapshot.data.taxProfiles || []).length,
+        financialGoalsToCreate: (snapshot.data.financialGoals || []).length,
+        projectionScenariosToCreate: (snapshot.data.projectionScenarios || []).length,
+        importMappingTemplatesToRestore: importBackup?.mappingTemplates?.length || 0,
+        importHistoryItemsToRestore: importBackup?.importHistory?.length || 0,
+        existingAccountsToReplace: current.accounts?.length || 0,
+        existingCategoriesToReplace: current.categories?.length || 0,
+        existingBudgetTargetsToReplace: current.budgetTargets?.length || 0,
+        existingRecurringTemplatesToReplace: current.recurringTemplates?.length || 0,
+        existingTransactionsToReplace: current.transactions?.length || 0,
+        existingTaxProfilesToReplace: current.taxProfiles?.length || 0,
+    }
+}
+
+export function createRestoreDryRunReport(
+    snapshot: BudgetBackupWithImportDataSnapshot,
+    current: RestoreDryRunCurrentState = {},
+): RestoreDryRunReport {
+    const warnings: string[] = []
+    const blockingErrors: string[] = []
+    const ignoredItems: string[] = []
+    const legacySnapshot = snapshot as unknown as BudgetBackupSnapshot
+
+    validateRoot(snapshot, blockingErrors)
+    validateRequiredSections(legacySnapshot, blockingErrors)
+
+    addDuplicateIdErrors(legacySnapshot.data.accounts, 'Comptes', blockingErrors)
+    addDuplicateIdErrors(legacySnapshot.data.categories, 'Catégories', blockingErrors)
+    addDuplicateIdErrors(legacySnapshot.data.budgetTargets, 'Budgets', blockingErrors)
+    addDuplicateIdErrors(legacySnapshot.data.recurringTemplates, 'Récurrences', blockingErrors)
+    addDuplicateIdErrors(legacySnapshot.data.transactions, 'Transactions', blockingErrors)
+    addDuplicateIdErrors(legacySnapshot.data.taxProfiles || [], 'Profils fiscaux', blockingErrors)
+
+    const accountIds = new Set(legacySnapshot.data.accounts.map((account) => account.id))
+    const categoryIds = new Set(legacySnapshot.data.categories.map((category) => category.id))
+
+    validateAccounts(legacySnapshot, blockingErrors, warnings)
+    validateCategories(legacySnapshot, warnings)
+    validateBudgetTargets(legacySnapshot, categoryIds, blockingErrors, warnings)
+    validateRecurringTemplates(legacySnapshot, accountIds, categoryIds, blockingErrors, warnings)
+    validateTransactions(legacySnapshot, accountIds, categoryIds, blockingErrors, warnings)
+    validateTaxProfiles(legacySnapshot, blockingErrors)
+    validateGoals(snapshot, blockingErrors, warnings)
+    validateImportBackup(snapshot, blockingErrors, warnings, ignoredItems)
+
+    const uniqueBlockingErrors = [...new Set(blockingErrors)]
+    const uniqueWarnings = [...new Set(warnings)]
+    const uniqueIgnoredItems = [...new Set(ignoredItems)]
+
+    return {
+        ok: uniqueBlockingErrors.length === 0,
+        canApply: uniqueBlockingErrors.length === 0,
+        source: {
+            kind: snapshot.kind,
+            version: snapshot.version,
+            exportedAt: snapshot.exportedAt || null,
+        },
+        counts: buildCounts(snapshot, current),
+        ignoredItems: uniqueIgnoredItems,
+        warnings: uniqueWarnings,
+        blockingErrors: uniqueBlockingErrors,
+        recovery: {
+            preRestoreBackupRequired: true,
+            createdBeforeWrite: false,
+            path: null,
+        },
+    }
+}
+
+export function markRecoveryBackupCreated(report: RestoreDryRunReport, path: string | null): RestoreDryRunReport {
+    return {
+        ...report,
+        recovery: {
+            ...report.recovery,
+            createdBeforeWrite: Boolean(path),
+            path,
+        },
+    }
+}


### PR DESCRIPTION
## Summary

- add `createRestoreDryRunReport` to validate restore snapshots before any write
- report blocking errors, warnings, ignored items, source metadata, create counts and current data replacement counts
- block restore when dry-run errors are present
- create a mandatory pre-restore JSON backup before deleting or recreating data
- keep encrypted and plain restore paths going through the same post-parse validation flow
- show blocking restore errors in the preview dialog
- add tests proving dry-run validation does not write, blocking errors stop restore, and recovery backup is saved before database changes

Closes #90.

## Testing

- Not run locally in this environment.
- Added/updated targeted tests:
  - `src/test/utils/restoreDryRun.test.ts`
  - `src/test/composables/useJsonBackup.restore.test.ts`