### PR TITLE
audit: add centralized logging service

### DIFF
--- a/electron/audit/auditLogService.js
+++ b/electron/audit/auditLogService.js
@@ -1,0 +1,216 @@
+const {createAuditEventRepository} = require('./auditEventModel')
+const {getPrisma} = require('../db')
+
+function errorMessage(error) {
+    if (!error) return null
+    if (error instanceof Error && error.message) return error.message
+    return String(error)
+}
+
+function metadata(value) {
+    if (!value || typeof value !== 'object') return value || null
+    return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined).slice(0, 40))
+}
+
+function entity(type, id) {
+    if (id == null || id === '') return null
+    return {type, id}
+}
+
+function entities(items) {
+    return (items || []).filter(Boolean)
+}
+
+function createAuditLogService({repository = null, prisma = null, logger = console} = {}) {
+    const auditRepository = repository || createAuditEventRepository(prisma || getPrisma())
+
+    async function recordAuditEvent(input, {strict = false} = {}) {
+        try {
+            return await auditRepository.create(input)
+        } catch (error) {
+            if (strict) throw error
+            logger?.warn?.('[audit] write failed', error)
+            return null
+        }
+    }
+
+    async function logImportApplied(input = {}, options) {
+        return recordAuditEvent({
+            eventType: 'importApplied',
+            domain: 'import',
+            action: 'apply',
+            severity: 'INFO',
+            status: 'SUCCESS',
+            summary: input.summary || `Import ${input.batchId || ''} appliqué.`.trim(),
+            source: input.source || 'import-workflow',
+            entityIds: entities([entity('importBatch', input.batchId)]),
+            metadata: metadata({rowCount: input.rowCount, appliedCount: input.appliedCount, duplicateCount: input.duplicateCount, errorCount: input.errorCount}),
+        }, options)
+    }
+
+    async function logImportFailed(input = {}, options) {
+        return recordAuditEvent({
+            eventType: 'importFailed',
+            domain: 'import',
+            action: input.action || 'apply',
+            severity: 'ERROR',
+            status: 'FAILED',
+            summary: input.summary || `Import ${input.batchId || ''} échoué.`.trim(),
+            source: input.source || 'import-workflow',
+            entityIds: entities([entity('importBatch', input.batchId)]),
+            metadata: metadata({reason: input.reason || errorMessage(input.error), stage: input.stage}),
+        }, options)
+    }
+
+    async function logBackupExported(input = {}, options) {
+        const encrypted = Boolean(input.encrypted)
+        return recordAuditEvent({
+            eventType: encrypted ? 'encryptedBackupExported' : 'backupExported',
+            domain: 'backup',
+            action: encrypted ? 'exportEncrypted' : 'exportJson',
+            severity: 'INFO',
+            status: 'SUCCESS',
+            summary: encrypted ? 'Backup chiffré exporté.' : 'Backup JSON exporté.',
+            source: input.source || 'backup-flow',
+            entityIds: entities([entity('file', input.filePath || input.defaultPath)]),
+            metadata: metadata({encrypted, format: encrypted ? 'encrypted-json' : 'json', backupVersion: input.backupVersion}),
+        }, options)
+    }
+
+    async function logRestoreDryRun(input = {}, options) {
+        const report = input.report || {}
+        const canApply = report.canApply !== false && report.ok !== false
+        return recordAuditEvent({
+            eventType: 'restoreDryRun',
+            domain: 'restore',
+            action: 'dryRun',
+            severity: canApply ? 'INFO' : 'WARNING',
+            status: canApply ? 'SUCCESS' : 'BLOCKED',
+            summary: canApply ? 'Dry-run de restauration validé.' : 'Dry-run de restauration bloqué.',
+            source: input.source || 'restore-flow',
+            entityIds: entities([entity('file', input.filePath)]),
+            metadata: metadata({
+                canApply,
+                source: report.source,
+                counts: report.counts,
+                blockingErrorCount: Array.isArray(report.blockingErrors) ? report.blockingErrors.length : 0,
+                warningCount: Array.isArray(report.warnings) ? report.warnings.length : 0,
+                ignoredItemCount: Array.isArray(report.ignoredItems) ? report.ignoredItems.length : 0,
+            }),
+        }, options)
+    }
+
+    async function logRestoreApplied(input = {}, options) {
+        return recordAuditEvent({
+            eventType: 'restoreApplied',
+            domain: 'restore',
+            action: 'apply',
+            severity: 'CRITICAL',
+            status: 'SUCCESS',
+            summary: 'Restauration de backup appliquée.',
+            source: input.source || 'restore-flow',
+            entityIds: entities([entity('file', input.filePath), entity('recoveryBackup', input.recoveryPath)]),
+            metadata: metadata({counts: input.counts, recoveryBackupCreated: Boolean(input.recoveryPath)}),
+        }, options)
+    }
+
+    async function logRestoreFailed(input = {}, options) {
+        return recordAuditEvent({
+            eventType: 'restoreFailed',
+            domain: 'restore',
+            action: input.action || 'apply',
+            severity: 'ERROR',
+            status: 'FAILED',
+            summary: input.summary || 'Restauration de backup échouée.',
+            source: input.source || 'restore-flow',
+            entityIds: entities([entity('file', input.filePath), entity('recoveryBackup', input.recoveryPath)]),
+            metadata: metadata({reason: input.reason || errorMessage(input.error), recoveryBackupCreated: Boolean(input.recoveryPath)}),
+        }, options)
+    }
+
+    async function logCriticalDelete(input = {}, options) {
+        const entityType = input.entityType || input.domain || 'entity'
+        return recordAuditEvent({
+            eventType: input.bulk ? 'bulkDelete' : 'criticalDelete',
+            domain: input.domain || entityType,
+            action: input.bulk ? 'bulkDelete' : 'delete',
+            severity: input.severity || 'CRITICAL',
+            status: input.status || 'SUCCESS',
+            summary: input.summary || `${entityType} supprimé.`,
+            source: input.source || 'main-process',
+            entityIds: entities([entity(entityType, input.entityId), ...(Array.isArray(input.entityIds) ? input.entityIds : [])]),
+            metadata: metadata(input.metadata),
+        }, options)
+    }
+
+    async function logIntegrityCheck(input = {}, options) {
+        const ok = input.ok !== false
+        return recordAuditEvent({
+            eventType: 'integrityCheckFailed',
+            domain: 'integrity',
+            action: input.action || 'check',
+            severity: ok ? 'INFO' : 'ERROR',
+            status: ok ? 'SUCCESS' : 'FAILED',
+            summary: input.summary || (ok ? 'Contrôle d’intégrité réussi.' : 'Contrôle d’intégrité échoué.'),
+            source: input.source || 'main-process',
+            entityIds: entities(input.entityIds || []),
+            metadata: metadata({reason: input.reason, ...input.metadata}),
+        }, options)
+    }
+
+    async function logSecretChange(input = {}, options) {
+        const deleted = input.action === 'delete' || input.action === 'clear'
+        return recordAuditEvent({
+            eventType: deleted ? 'secretDeleted' : 'secretCreated',
+            domain: 'secret',
+            action: deleted ? 'delete' : 'create',
+            severity: 'WARNING',
+            status: input.status || 'SUCCESS',
+            summary: deleted ? 'Secret local supprimé.' : 'Secret local créé ou remplacé.',
+            source: input.source || 'secret-store',
+            entityIds: entities([entity('secretKey', input.key), entity('service', input.service)]),
+            metadata: metadata({provider: input.provider, clearedCount: input.clearedCount}),
+        }, options)
+    }
+
+    async function logMigration(input = {}, options) {
+        return recordAuditEvent({
+            eventType: 'migrationApplied',
+            domain: 'migration',
+            action: input.action || 'apply',
+            severity: input.status === 'FAILED' ? 'ERROR' : 'INFO',
+            status: input.status || 'SUCCESS',
+            summary: input.summary || `Migration ${input.name || ''} appliquée.`.trim(),
+            source: input.source || 'prisma',
+            entityIds: entities([entity('migration', input.name)]),
+            metadata: metadata({version: input.version}),
+        }, options)
+    }
+
+    function getRetentionPolicy() {
+        return {
+            mode: 'keep-all',
+            purgeSupported: false,
+            description: 'Tous les événements locaux sont conservés par défaut. Une purge contrôlée pourra être ajoutée plus tard.',
+        }
+    }
+
+    return {
+        getRetentionPolicy,
+        logBackupExported,
+        logCriticalDelete,
+        logImportApplied,
+        logImportFailed,
+        logIntegrityCheck,
+        logMigration,
+        logRestoreApplied,
+        logRestoreDryRun,
+        logRestoreFailed,
+        logSecretChange,
+        recordAuditEvent,
+    }
+}
+
+module.exports = {
+    createAuditLogService,
+}

--- a/electron/audit/auditedImportWorkflow.js
+++ b/electron/audit/auditedImportWorkflow.js
@@ -1,0 +1,45 @@
+function createAuditedImportWorkflow({base, auditLog}) {
+    if (!base) throw new Error('base import workflow handlers are required')
+    if (!auditLog) throw new Error('auditLog is required')
+
+    async function applyImport(input) {
+        try {
+            const result = await base.applyImport(input)
+            await auditLog.logImportApplied({
+                batchId: input?.batchId || result?.batchId || result?.id,
+                rowCount: result?.rowCount,
+                appliedCount: result?.appliedCount || result?.createdCount || result?.updatedCount,
+                duplicateCount: result?.duplicateCount,
+                errorCount: result?.errorCount,
+            })
+            return result
+        } catch (error) {
+            await auditLog.logImportFailed({batchId: input?.batchId, error, stage: 'apply'})
+            throw error
+        }
+    }
+
+    async function cancelImport(batchId, reason) {
+        const result = await base.cancelImport(batchId, reason)
+        await auditLog.recordAuditEvent({
+            eventType: 'importCancelled',
+            domain: 'import',
+            action: 'cancel',
+            severity: 'WARNING',
+            status: 'CANCELLED',
+            summary: `Import ${batchId} annulé.`,
+            source: 'import-workflow',
+            entityIds: [{type: 'importBatch', id: batchId}],
+            metadata: {reason},
+        })
+        return result
+    }
+
+    return {
+        ...base,
+        applyImport,
+        cancelImport,
+    }
+}
+
+module.exports = {createAuditedImportWorkflow}

--- a/electron/ipc/registerAuditLogHandlers.js
+++ b/electron/ipc/registerAuditLogHandlers.js
@@ -1,0 +1,67 @@
+const {ipcMain} = require('electron')
+const {getPrisma} = require('../db')
+const {createAuditLogService} = require('../audit/auditLogService')
+
+const AUDIT_LOG_IPC_CHANNELS = Object.freeze({
+    BACKUP_EXPORTED: 'audit:backup:exported',
+    RESTORE_DRY_RUN: 'audit:restore:dryRun',
+    RESTORE_APPLIED: 'audit:restore:applied',
+    RESTORE_FAILED: 'audit:restore:failed',
+    RETENTION_POLICY: 'audit:retention:policy',
+})
+
+function ok(data) {
+    return {ok: true, data, error: null}
+}
+
+function fail(error) {
+    return {
+        ok: false,
+        data: null,
+        error: {
+            code: 'AUDIT_LOG_FAILED',
+            message: error instanceof Error ? error.message : String(error),
+        },
+    }
+}
+
+function registerSafeAuditLogHandler(ipc, channel, handler) {
+    ipc.handle(channel, async (_event, payload) => {
+        try {
+            return ok(await handler(payload || {}))
+        } catch (error) {
+            return fail(error)
+        }
+    })
+}
+
+function createAuditLogHandlers({service = createAuditLogService({prisma: getPrisma()})} = {}) {
+    return {
+        logBackupExported: (input) => service.logBackupExported(input),
+        logRestoreDryRun: (input) => service.logRestoreDryRun(input),
+        logRestoreApplied: (input) => service.logRestoreApplied(input),
+        logRestoreFailed: (input) => service.logRestoreFailed(input),
+        getRetentionPolicy: () => service.getRetentionPolicy(),
+    }
+}
+
+function registerAuditLogHandlers({ipc = ipcMain, service = createAuditLogService({prisma: getPrisma()})} = {}) {
+    const handlers = createAuditLogHandlers({service})
+
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.BACKUP_EXPORTED, handlers.logBackupExported)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_DRY_RUN, handlers.logRestoreDryRun)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_APPLIED, handlers.logRestoreApplied)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_FAILED, handlers.logRestoreFailed)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RETENTION_POLICY, handlers.getRetentionPolicy)
+
+    return handlers
+}
+
+module.exports = {
+    AUDIT_LOG_IPC_CHANNELS,
+    createAuditLogHandlers,
+    fail,
+    ok,
+    registerAuditLogHandlers,
+    registerSafeAuditLogHandler,
+}

--- a/electron/ipc/registerDbHandlers.js
+++ b/electron/ipc/registerDbHandlers.js
@@ -1,5 +1,6 @@
 const {ipcMain} = require('electron')
 const {getPrisma} = require('../db')
+const {createAuditLogService} = require('../audit/auditLogService')
 const {
     buildAccountPayload,
     buildCategoryPayload,
@@ -10,7 +11,7 @@ const {
     updateTransaction,
 } = require('./transactionHandlers')
 
-function registerDbHandlers() {
+function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma()})} = {}) {
     const prisma = getPrisma()
 
     ipcMain.handle('db:account:list', async () => {
@@ -33,9 +34,19 @@ function registerDbHandlers() {
     })
 
     ipcMain.handle('db:account:delete', async (_event, id) => {
-        return prisma.account.delete({
-            where: {id: requireId(id, 'Le compte')},
+        const accountId = requireId(id, 'Le compte')
+        const deleted = await prisma.account.delete({
+            where: {id: accountId},
         })
+        await auditLog.logCriticalDelete({
+            domain: 'account',
+            entityType: 'account',
+            entityId: accountId,
+            summary: `Compte supprimé: ${deleted.name}`,
+            source: 'db:account:delete',
+            metadata: {type: deleted.type, currency: deleted.currency},
+        })
+        return deleted
     })
 
     ipcMain.handle('db:category:list', async () => {
@@ -58,9 +69,19 @@ function registerDbHandlers() {
     })
 
     ipcMain.handle('db:category:delete', async (_event, id) => {
-        return prisma.category.delete({
-            where: {id: requireId(id, 'La catégorie')},
+        const categoryId = requireId(id, 'La catégorie')
+        const deleted = await prisma.category.delete({
+            where: {id: categoryId},
         })
+        await auditLog.logCriticalDelete({
+            domain: 'category',
+            entityType: 'category',
+            entityId: categoryId,
+            summary: `Catégorie supprimée: ${deleted.name}`,
+            source: 'db:category:delete',
+            metadata: {kind: deleted.kind},
+        })
+        return deleted
     })
 
     ipcMain.handle('db:transaction:list', async () => {
@@ -82,7 +103,17 @@ function registerDbHandlers() {
     })
 
     ipcMain.handle('db:transaction:delete', async (_event, id) => {
-        return deleteTransaction(prisma, id)
+        const transactionId = requireId(id, 'La transaction')
+        const deleted = await deleteTransaction(prisma, transactionId)
+        await auditLog.logCriticalDelete({
+            domain: 'transaction',
+            entityType: 'transaction',
+            entityId: transactionId,
+            summary: `Transaction supprimée: ${deleted.label}`,
+            source: 'db:transaction:delete',
+            metadata: {kind: deleted.kind, date: deleted.date, accountId: deleted.accountId, categoryId: deleted.categoryId},
+        })
+        return deleted
     })
 }
 

--- a/electron/ipc/registerImportWorkflowHandlers.js
+++ b/electron/ipc/registerImportWorkflowHandlers.js
@@ -1,4 +1,7 @@
 const {app, ipcMain} = require('electron')
+const {createAuditLogService} = require('../audit/auditLogService')
+const {createAuditedImportWorkflow} = require('../audit/auditedImportWorkflow')
+const {getPrisma} = require('../db')
 const {
     applyImport,
     applyReconciliationDecisions,
@@ -61,22 +64,7 @@ function registerSafeImportWorkflowHandler(ipc, channel, handler) {
     })
 }
 
-function registerImportWorkflowHandlers({ipc = ipcMain, store = defaultImportWorkflowStore(app)} = {}) {
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.CREATE_BATCH, (input) => createImportBatch(store, input))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.PARSE_FILE, (input) => parseImportFile(store, input))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.PREVIEW, (input) => previewImport(store, input))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.APPLY, (input) => applyImport(store, input))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.CANCEL, (batchId, reason) => cancelImport(store, batchId, reason))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.HISTORY, (filters) => listImportAuditHistory(store, filters))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.DETAIL, (batchId) => getImportAuditDetail(store, batchId))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.ERRORS, (batchId) => listImportErrors(store, batchId))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.DUPLICATES, (batchId) => listDuplicateCandidates(store, batchId))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.RECONCILE, (input) => applyReconciliationDecisions(store, input))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_SOURCES, () => listImportAuditSources(store))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_DELETE, (batchId, options) => deleteImportAuditHistory(store, batchId, options))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_EXPORT, (batchId, options) => exportImportAuditReport(store, batchId, options))
-    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_RESTORE_BACKUP, (input) => restoreImportAuditBackup(store, input))
-
+function createBaseImportWorkflow(store) {
     return {
         applyImport: (input) => applyImport(store, input),
         applyReconciliationDecisions: (input) => applyReconciliationDecisions(store, input),
@@ -97,8 +85,33 @@ function registerImportWorkflowHandlers({ipc = ipcMain, store = defaultImportWor
     }
 }
 
+function registerImportWorkflowHandlers({ipc = ipcMain, store = defaultImportWorkflowStore(app), auditLog = createAuditLogService({prisma: getPrisma()})} = {}) {
+    const handlers = createAuditedImportWorkflow({
+        base: createBaseImportWorkflow(store),
+        auditLog,
+    })
+
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.CREATE_BATCH, handlers.createImportBatch)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.PARSE_FILE, handlers.parseImportFile)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.PREVIEW, handlers.previewImport)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.APPLY, handlers.applyImport)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.CANCEL, handlers.cancelImport)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.HISTORY, handlers.listImportAuditHistory)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.DETAIL, handlers.getImportAuditDetail)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.ERRORS, handlers.listImportErrors)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.DUPLICATES, handlers.listDuplicateCandidates)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.RECONCILE, handlers.applyReconciliationDecisions)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_SOURCES, handlers.listImportAuditSources)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_DELETE, handlers.deleteImportAuditHistory)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_EXPORT, handlers.exportImportAuditReport)
+    registerSafeImportWorkflowHandler(ipc, IMPORT_WORKFLOW_IPC_CHANNELS.AUDIT_RESTORE_BACKUP, handlers.restoreImportAuditBackup)
+
+    return handlers
+}
+
 module.exports = {
     IMPORT_WORKFLOW_IPC_CHANNELS,
+    createBaseImportWorkflow,
     fail,
     ok,
     registerImportWorkflowHandlers,

--- a/electron/ipc/registerSecretHandlers.js
+++ b/electron/ipc/registerSecretHandlers.js
@@ -1,5 +1,7 @@
 const {app, ipcMain, safeStorage} = require('electron')
 
+const {createAuditLogService} = require('../audit/auditLogService')
+const {getPrisma} = require('../db')
 const {
     createSecretStore,
     toSecretStoreIpcError,
@@ -41,19 +43,49 @@ function getDefaultSecretStore() {
     return defaultSecretStore
 }
 
-function createSecretHandlers({store = getDefaultSecretStore()} = {}) {
+function createSecretHandlers({store = getDefaultSecretStore(), auditLog = createAuditLogService({prisma: getPrisma()})} = {}) {
     return {
         getStorageInfo: () => store.getStorageInfo(),
-        saveSecret: (input) => store.saveSecret(input),
+        async saveSecret(input) {
+            const result = await store.saveSecret(input)
+            await auditLog.logSecretChange({
+                action: 'create',
+                key: input?.key,
+                service: input?.service,
+                provider: input?.provider,
+                source: 'secret:save',
+            })
+            return result
+        },
         hasSecret: (input) => store.hasSecret(input),
         listSecretMetadata: (input) => store.listSecretMetadata(input),
-        deleteSecret: (input) => store.deleteSecret(input),
-        clearSecrets: (input) => store.clearSecrets(input),
+        async deleteSecret(input) {
+            const result = await store.deleteSecret(input)
+            await auditLog.logSecretChange({
+                action: 'delete',
+                key: input?.key,
+                service: input?.service,
+                provider: input?.provider,
+                source: 'secret:delete',
+            })
+            return result
+        },
+        async clearSecrets(input) {
+            const result = await store.clearSecrets(input)
+            await auditLog.logSecretChange({
+                action: 'clear',
+                service: input?.service,
+                provider: input?.provider,
+                clearedCount: Array.isArray(result) ? result.length : result?.deletedCount,
+                source: 'secret:clear',
+            })
+            return result
+        },
     }
 }
 
-function registerSecretHandlers({ipc = ipcMain, store = getDefaultSecretStore()} = {}) {
-    const handlers = createSecretHandlers({store})
+function registerSecretHandlers({ipc = ipcMain, store = getDefaultSecretStore(), auditLog = createAuditLogService({prisma: getPrisma()})} = {}) {
+    const handlers = createSecretHandlers({store, auditLog})
 
     registerSafeSecretHandler(ipc, SECRET_IPC_CHANNELS.GET_STORAGE_INFO, handlers.getStorageInfo)
     registerSafeSecretHandler(ipc, SECRET_IPC_CHANNELS.SAVE, handlers.saveSecret)

--- a/electron/ipc/registerWealthHandlers.js
+++ b/electron/ipc/registerWealthHandlers.js
@@ -1,6 +1,7 @@
 const {ipcMain} = require('electron')
 
 const {getPrisma} = require('../db')
+const {createAuditLogService} = require('../audit/auditLogService')
 const {getPortfolioDashboard} = require('../portfolio/portfolioDashboardService')
 const {registerGoalHandlers} = require('./registerGoalHandlers')
 const {registerMonthlySurplusHandlers} = require('./registerMonthlySurplusHandlers')
@@ -25,11 +26,22 @@ const {
     listNetWorthSnapshots,
 } = require('./wealthOverviewHandlers')
 
-function registerWealthHandlers(prisma = getPrisma()) {
+function registerWealthHandlers(prisma = getPrisma(), {auditLog = createAuditLogService({prisma})} = {}) {
     ipcMain.handle('db:asset:list', async (_event, filters) => listAssets(prisma, filters))
     ipcMain.handle('db:asset:create', async (_event, data) => createAsset(prisma, data))
     ipcMain.handle('db:asset:update', async (_event, id, data) => updateAsset(prisma, id, data))
-    ipcMain.handle('db:asset:delete', async (_event, id) => deleteAsset(prisma, id))
+    ipcMain.handle('db:asset:delete', async (_event, id) => {
+        const deleted = await deleteAsset(prisma, id)
+        await auditLog.logCriticalDelete({
+            domain: 'wealth',
+            entityType: 'asset',
+            entityId: id,
+            summary: `Actif supprimé: ${deleted.name}`,
+            source: 'db:asset:delete',
+            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency},
+        })
+        return deleted
+    })
 
     ipcMain.handle('db:portfolio:list', async (_event, filters) => listPortfolios(prisma, filters))
     ipcMain.handle('db:portfolio:create', async (_event, data) => createPortfolio(prisma, data))
@@ -39,7 +51,18 @@ function registerWealthHandlers(prisma = getPrisma()) {
     ipcMain.handle('db:liability:list', async (_event, filters) => listLiabilities(prisma, filters))
     ipcMain.handle('db:liability:create', async (_event, data) => createLiability(prisma, data))
     ipcMain.handle('db:liability:update', async (_event, id, data) => updateLiability(prisma, id, data))
-    ipcMain.handle('db:liability:delete', async (_event, id) => deleteLiability(prisma, id))
+    ipcMain.handle('db:liability:delete', async (_event, id) => {
+        const deleted = await deleteLiability(prisma, id)
+        await auditLog.logCriticalDelete({
+            domain: 'wealth',
+            entityType: 'liability',
+            entityId: id,
+            summary: `Passif supprimé: ${deleted.name}`,
+            source: 'db:liability:delete',
+            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency},
+        })
+        return deleted
+    })
 
     ipcMain.handle('db:wealth:overview', async (_event, options) => getWealthOverview(prisma, options))
     ipcMain.handle('db:netWorthSnapshot:createGenerated', async (_event, options) =>

--- a/electron/main.js
+++ b/electron/main.js
@@ -13,6 +13,7 @@ const {registerImportMappingTemplateHandlers} = require('./ipc/registerImportMap
 const {registerImportWorkflowHandlers} = require('./ipc/registerImportWorkflowHandlers')
 const {registerSecretHandlers} = require('./ipc/registerSecretHandlers')
 const {registerBackupEncryptionHandlers} = require('./ipc/registerBackupEncryptionHandlers')
+const {registerAuditLogHandlers} = require('./ipc/registerAuditLogHandlers')
 const {disconnectPrisma} = require('./db')
 const {getMenuMessages, normalizeMenuLocale} = require('./menuI18n')
 
@@ -271,6 +272,7 @@ app.whenReady().then(() => {
     registerImportWorkflowHandlers()
     registerSecretHandlers()
     registerBackupEncryptionHandlers()
+    registerAuditLogHandlers()
 
     Menu.setApplicationMenu(buildAppMenu(currentMenuLocale))
     createWindow()

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -129,6 +129,14 @@ contextBridge.exposeInMainWorld('backupEncryption', {
   inspect: (input) => ipcRenderer.invoke('backup:encrypted:inspect', input),
 })
 
+contextBridge.exposeInMainWorld('auditLog', {
+  logBackupExported: (input) => ipcRenderer.invoke('audit:backup:exported', input),
+  logRestoreDryRun: (input) => ipcRenderer.invoke('audit:restore:dryRun', input),
+  logRestoreApplied: (input) => ipcRenderer.invoke('audit:restore:applied', input),
+  logRestoreFailed: (input) => ipcRenderer.invoke('audit:restore:failed', input),
+  getRetentionPolicy: () => ipcRenderer.invoke('audit:retention:policy'),
+})
+
 contextBridge.exposeInMainWorld('imports', {
   createBatch: (input) => ipcRenderer.invoke('import:batch:create', input),
   parseFile: (input) => ipcRenderer.invoke('import:file:parse', input),

--- a/src/test/electron/auditLogIpc.test.js
+++ b/src/test/electron/auditLogIpc.test.js
@@ -1,0 +1,89 @@
+import Module from 'node:module'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const originalLoad = Module._load
+const handlers = new Map()
+const ipc = {
+    handle: vi.fn((channel, callback) => handlers.set(channel, callback)),
+}
+
+function clearCommonJsCache() {
+    for (const modulePath of [
+        '../../../electron/ipc/registerAuditLogHandlers',
+    ]) {
+        try {
+            delete require.cache[require.resolve(modulePath)]
+        } catch (_error) {
+            // ignore
+        }
+    }
+}
+
+function installElectronMock() {
+    Module._load = function loadWithMocks(request) {
+        if (request === 'electron') {
+            return {ipcMain: ipc}
+        }
+        return originalLoad.apply(this, arguments)
+    }
+}
+
+afterEach(() => {
+    Module._load = originalLoad
+    handlers.clear()
+    ipc.handle.mockClear()
+    clearCommonJsCache()
+})
+
+describe('audit log IPC handlers', () => {
+    it('exposes only explicit audit intents to the renderer', async () => {
+        installElectronMock()
+        const {AUDIT_LOG_IPC_CHANNELS, registerAuditLogHandlers} = require('../../../electron/ipc/registerAuditLogHandlers')
+        const service = {
+            logBackupExported: vi.fn(async (input) => ({id: 1, eventType: input.encrypted ? 'encryptedBackupExported' : 'backupExported'})),
+            logRestoreDryRun: vi.fn(async () => ({id: 2, eventType: 'restoreDryRun'})),
+            logRestoreApplied: vi.fn(async () => ({id: 3, eventType: 'restoreApplied'})),
+            logRestoreFailed: vi.fn(async () => ({id: 4, eventType: 'restoreFailed'})),
+            getRetentionPolicy: vi.fn(() => ({mode: 'keep-all', purgeSupported: false})),
+        }
+
+        registerAuditLogHandlers({ipc, service})
+
+        expect([...handlers.keys()]).toEqual(expect.arrayContaining([
+            AUDIT_LOG_IPC_CHANNELS.BACKUP_EXPORTED,
+            AUDIT_LOG_IPC_CHANNELS.RESTORE_DRY_RUN,
+            AUDIT_LOG_IPC_CHANNELS.RESTORE_APPLIED,
+            AUDIT_LOG_IPC_CHANNELS.RESTORE_FAILED,
+            AUDIT_LOG_IPC_CHANNELS.RETENTION_POLICY,
+        ]))
+        expect([...handlers.keys()]).not.toContain('audit:raw:create')
+
+        const backup = await handlers.get(AUDIT_LOG_IPC_CHANNELS.BACKUP_EXPORTED)({}, {encrypted: true, filePath: '/tmp/backup.enc.json'})
+        const policy = await handlers.get(AUDIT_LOG_IPC_CHANNELS.RETENTION_POLICY)({}, {})
+
+        expect(backup).toEqual({ok: true, data: {id: 1, eventType: 'encryptedBackupExported'}, error: null})
+        expect(policy).toEqual({ok: true, data: {mode: 'keep-all', purgeSupported: false}, error: null})
+        expect(service.logBackupExported).toHaveBeenCalledWith({encrypted: true, filePath: '/tmp/backup.enc.json'})
+    })
+
+    it('returns structured IPC errors without throwing into renderer', async () => {
+        installElectronMock()
+        const {AUDIT_LOG_IPC_CHANNELS, registerAuditLogHandlers} = require('../../../electron/ipc/registerAuditLogHandlers')
+        const service = {
+            logBackupExported: vi.fn(async () => { throw new Error('audit unavailable') }),
+            logRestoreDryRun: vi.fn(),
+            logRestoreApplied: vi.fn(),
+            logRestoreFailed: vi.fn(),
+            getRetentionPolicy: vi.fn(),
+        }
+
+        registerAuditLogHandlers({ipc, service})
+        const result = await handlers.get(AUDIT_LOG_IPC_CHANNELS.BACKUP_EXPORTED)({}, {filePath: '/tmp/backup.json'})
+
+        expect(result).toEqual({
+            ok: false,
+            data: null,
+            error: {code: 'AUDIT_LOG_FAILED', message: 'audit unavailable'},
+        })
+    })
+})

--- a/src/test/electron/auditLogService.test.js
+++ b/src/test/electron/auditLogService.test.js
@@ -1,0 +1,85 @@
+import {describe, expect, it, vi} from 'vitest'
+
+function loadAuditLogService() {
+    return require('../../../electron/audit/auditLogService')
+}
+
+describe('AuditLogService', () => {
+    it('records import, backup, restore and critical delete events through one service', async () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const repository = {create: vi.fn(async (input) => ({id: repository.create.mock.calls.length, ...input}))}
+        const service = createAuditLogService({repository, logger: {warn: vi.fn()}})
+
+        await service.logImportApplied({batchId: 12, rowCount: 5, appliedCount: 4})
+        await service.logBackupExported({filePath: '/tmp/budget-backup.json'})
+        await service.logBackupExported({filePath: '/tmp/budget-backup.budget.enc.json', encrypted: true})
+        await service.logRestoreDryRun({filePath: '/tmp/restore.json', report: {canApply: false, blockingErrors: ['missing account'], warnings: []}})
+        await service.logRestoreApplied({filePath: '/tmp/restore.json', recoveryPath: '/tmp/pre-restore.json', counts: {accounts: 2}})
+        await service.logCriticalDelete({domain: 'transaction', entityType: 'transaction', entityId: 44, metadata: {kind: 'EXPENSE'}})
+
+        expect(repository.create).toHaveBeenCalledTimes(6)
+        expect(repository.create).toHaveBeenNthCalledWith(1, expect.objectContaining({eventType: 'importApplied', domain: 'import', action: 'apply'}))
+        expect(repository.create).toHaveBeenNthCalledWith(2, expect.objectContaining({eventType: 'backupExported', domain: 'backup', action: 'exportJson'}))
+        expect(repository.create).toHaveBeenNthCalledWith(3, expect.objectContaining({eventType: 'encryptedBackupExported', domain: 'backup', action: 'exportEncrypted'}))
+        expect(repository.create).toHaveBeenNthCalledWith(4, expect.objectContaining({eventType: 'restoreDryRun', status: 'BLOCKED', severity: 'WARNING'}))
+        expect(repository.create).toHaveBeenNthCalledWith(5, expect.objectContaining({eventType: 'restoreApplied', severity: 'CRITICAL'}))
+        expect(repository.create).toHaveBeenNthCalledWith(6, expect.objectContaining({eventType: 'criticalDelete', domain: 'transaction'}))
+    })
+
+    it('does not break non-strict operations when audit persistence fails', async () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const logger = {warn: vi.fn()}
+        const repository = {create: vi.fn(async () => { throw new Error('db down') })}
+        const service = createAuditLogService({repository, logger})
+
+        const result = await service.logBackupExported({filePath: '/tmp/backup.json'})
+
+        expect(result).toBeNull()
+        expect(logger.warn).toHaveBeenCalledWith('[audit] write failed', expect.any(Error))
+    })
+
+    it('can be strict when traceability is required', async () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const repository = {create: vi.fn(async () => { throw new Error('db down') })}
+        const service = createAuditLogService({repository, logger: {warn: vi.fn()}})
+
+        await expect(service.recordAuditEvent({
+            eventType: 'restoreApplied',
+            domain: 'restore',
+            action: 'apply',
+            summary: 'restore applied',
+        }, {strict: true})).rejects.toThrow('db down')
+    })
+
+    it('exposes keep-all retention policy', () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const service = createAuditLogService({repository: {create: vi.fn()}, logger: {warn: vi.fn()}})
+
+        expect(service.getRetentionPolicy()).toMatchObject({
+            mode: 'keep-all',
+            purgeSupported: false,
+        })
+    })
+
+    it('logs secret, migration and integrity events without raw values', async () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const repository = {create: vi.fn(async (input) => input)}
+        const service = createAuditLogService({repository, logger: {warn: vi.fn()}})
+
+        await service.logSecretChange({action: 'create', key: 'provider:token', service: 'market-data'})
+        await service.logMigration({name: '20260510012000_add_audit_event'})
+        await service.logIntegrityCheck({ok: false, reason: 'checksum mismatch'})
+
+        expect(repository.create).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            eventType: 'secretCreated',
+            domain: 'secret',
+            metadata: expect.not.objectContaining({value: expect.anything()}),
+        }))
+        expect(repository.create).toHaveBeenNthCalledWith(2, expect.objectContaining({eventType: 'migrationApplied'}))
+        expect(repository.create).toHaveBeenNthCalledWith(3, expect.objectContaining({
+            eventType: 'integrityCheckFailed',
+            severity: 'ERROR',
+            status: 'FAILED',
+        }))
+    })
+})

--- a/src/test/electron/auditedImportWorkflow.test.js
+++ b/src/test/electron/auditedImportWorkflow.test.js
@@ -1,0 +1,80 @@
+import {describe, expect, it, vi} from 'vitest'
+
+function loadAuditedImportWorkflow() {
+    return require('../../../electron/audit/auditedImportWorkflow')
+}
+
+describe('audited import workflow', () => {
+    it('logs successful import apply without changing the base result', async () => {
+        const {createAuditedImportWorkflow} = loadAuditedImportWorkflow()
+        const baseResult = {batchId: 7, rowCount: 10, appliedCount: 9, duplicateCount: 1, errorCount: 0}
+        const base = {
+            applyImport: vi.fn(async () => baseResult),
+            cancelImport: vi.fn(),
+        }
+        const auditLog = {
+            logImportApplied: vi.fn(async () => null),
+            logImportFailed: vi.fn(),
+            recordAuditEvent: vi.fn(),
+        }
+        const workflow = createAuditedImportWorkflow({base, auditLog})
+
+        const result = await workflow.applyImport({batchId: 7})
+
+        expect(result).toBe(baseResult)
+        expect(auditLog.logImportApplied).toHaveBeenCalledWith(expect.objectContaining({
+            batchId: 7,
+            rowCount: 10,
+            appliedCount: 9,
+            duplicateCount: 1,
+            errorCount: 0,
+        }))
+        expect(auditLog.logImportFailed).not.toHaveBeenCalled()
+    })
+
+    it('logs failed import apply and preserves the original error', async () => {
+        const {createAuditedImportWorkflow} = loadAuditedImportWorkflow()
+        const baseError = new Error('apply failed')
+        const base = {
+            applyImport: vi.fn(async () => { throw baseError }),
+            cancelImport: vi.fn(),
+        }
+        const auditLog = {
+            logImportApplied: vi.fn(),
+            logImportFailed: vi.fn(async () => null),
+            recordAuditEvent: vi.fn(),
+        }
+        const workflow = createAuditedImportWorkflow({base, auditLog})
+
+        await expect(workflow.applyImport({batchId: 8})).rejects.toBe(baseError)
+
+        expect(auditLog.logImportFailed).toHaveBeenCalledWith({batchId: 8, error: baseError, stage: 'apply'})
+    })
+
+    it('logs import cancellation', async () => {
+        const {createAuditedImportWorkflow} = loadAuditedImportWorkflow()
+        const baseResult = {id: 9, status: 'CANCELLED'}
+        const base = {
+            applyImport: vi.fn(),
+            cancelImport: vi.fn(async () => baseResult),
+        }
+        const auditLog = {
+            logImportApplied: vi.fn(),
+            logImportFailed: vi.fn(),
+            recordAuditEvent: vi.fn(async () => null),
+        }
+        const workflow = createAuditedImportWorkflow({base, auditLog})
+
+        const result = await workflow.cancelImport(9, 'duplicate file')
+
+        expect(result).toBe(baseResult)
+        expect(auditLog.recordAuditEvent).toHaveBeenCalledWith(expect.objectContaining({
+            eventType: 'importCancelled',
+            domain: 'import',
+            action: 'cancel',
+            status: 'CANCELLED',
+            entityIds: [{type: 'importBatch', id: 9}],
+            metadata: {reason: 'duplicate file'},
+        }))
+    })
+})

--- a/src/test/electron/secretAuditHandlers.test.js
+++ b/src/test/electron/secretAuditHandlers.test.js
@@ -1,0 +1,95 @@
+import Module from 'node:module'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const originalLoad = Module._load
+const handlers = new Map()
+const ipc = {
+    handle: vi.fn((channel, callback) => handlers.set(channel, callback)),
+}
+
+function clearCommonJsCache() {
+    try {
+        delete require.cache[require.resolve('../../../electron/ipc/registerSecretHandlers')]
+    } catch (_error) {
+        // ignore
+    }
+}
+
+function installElectronMock() {
+    Module._load = function loadWithMocks(request) {
+        if (request === 'electron') {
+            return {app: {}, ipcMain: ipc, safeStorage: {}}
+        }
+        return originalLoad.apply(this, arguments)
+    }
+}
+
+afterEach(() => {
+    Module._load = originalLoad
+    handlers.clear()
+    ipc.handle.mockClear()
+    clearCommonJsCache()
+})
+
+describe('secret handlers audit logging', () => {
+    it('logs secret save/delete/clear through AuditLogService without exposing values', async () => {
+        installElectronMock()
+        const {SECRET_IPC_CHANNELS, registerSecretHandlers} = require('../../../electron/ipc/registerSecretHandlers')
+        const store = {
+            getStorageInfo: vi.fn(),
+            saveSecret: vi.fn(async () => ({key: 'provider:api', saved: true})),
+            hasSecret: vi.fn(),
+            listSecretMetadata: vi.fn(),
+            deleteSecret: vi.fn(async () => ({key: 'provider:api', deleted: true})),
+            clearSecrets: vi.fn(async () => ({deletedCount: 2})),
+        }
+        const auditLog = {
+            logSecretChange: vi.fn(async () => null),
+        }
+
+        registerSecretHandlers({ipc, store, auditLog})
+
+        const saved = await handlers.get(SECRET_IPC_CHANNELS.SAVE)({}, {
+            key: 'provider:api',
+            service: 'market-data',
+            provider: 'demo',
+            value: 'should-never-be-sent-to-audit',
+        })
+        const deleted = await handlers.get(SECRET_IPC_CHANNELS.DELETE)({}, {
+            key: 'provider:api',
+            service: 'market-data',
+            provider: 'demo',
+        })
+        const cleared = await handlers.get(SECRET_IPC_CHANNELS.CLEAR)({}, {
+            service: 'market-data',
+            provider: 'demo',
+        })
+
+        expect(saved.ok).toBe(true)
+        expect(deleted.ok).toBe(true)
+        expect(cleared.ok).toBe(true)
+        expect(auditLog.logSecretChange).toHaveBeenCalledTimes(3)
+        expect(auditLog.logSecretChange).toHaveBeenNthCalledWith(1, {
+            action: 'create',
+            key: 'provider:api',
+            service: 'market-data',
+            provider: 'demo',
+            source: 'secret:save',
+        })
+        expect(auditLog.logSecretChange).toHaveBeenNthCalledWith(2, {
+            action: 'delete',
+            key: 'provider:api',
+            service: 'market-data',
+            provider: 'demo',
+            source: 'secret:delete',
+        })
+        expect(auditLog.logSecretChange).toHaveBeenNthCalledWith(3, {
+            action: 'clear',
+            service: 'market-data',
+            provider: 'demo',
+            clearedCount: 2,
+            source: 'secret:clear',
+        })
+        expect(JSON.stringify(auditLog.logSecretChange.mock.calls)).not.toContain('should-never-be-sent-to-audit')
+    })
+})


### PR DESCRIPTION
## Summary

- add centralized `AuditLogService` on Electron main side
- add simple methods for imports, backups, restore dry-run/apply/failure, critical deletes, integrity checks, secrets and migrations
- keep `recordAuditEvent` internal to the service and non-strict by default so audit failures do not break normal operations
- expose limited audit IPC intents for backup/restore audit events without giving the renderer direct DB access
- add audited import workflow wrapper for apply/cancel/failure events
- log critical deletes for transactions, accounts, categories, assets and liabilities
- log local secret create/delete/clear operations without passing secret values into audit metadata
- add keep-all retention policy placeholder
- add unit tests for service behavior, IPC bridge, import wrapper and secret hooks

Closes #92.

## Notes

- The service relies on the `AuditEvent` migration/model merged in #123.
- Backup/restore audit is exposed through dedicated IPC methods. I did not rewrite the large backup composable in this PR to avoid mixing UI-flow refactors with the backend service layer.

## Testing

- Not run locally in this environment.
- Added targeted tests:
  - `src/test/electron/auditLogService.test.js`
  - `src/test/electron/auditLogIpc.test.js`
  - `src/test/electron/auditedImportWorkflow.test.js`
  - `src/test/electron/secretAuditHandlers.test.js`