### PR TITLE
audit: add security history UI and exports

### DIFF
--- a/electron/audit/auditLogService.js
+++ b/electron/audit/auditLogService.js
@@ -21,6 +21,26 @@ function entities(items) {
     return (items || []).filter(Boolean)
 }
 
+function csvEscape(value) {
+    const text = value == null ? '' : String(value)
+    if (/[";\n\r]/.test(text)) return `"${text.replace(/"/g, '""')}"`
+    return text
+}
+
+function metadataSummary(value) {
+    if (!value || typeof value !== 'object') return ''
+    return Object.entries(value)
+        .slice(0, 12)
+        .map(([key, entry]) => `${key}: ${typeof entry === 'object' ? JSON.stringify(entry) : String(entry)}`)
+        .join('; ')
+}
+
+function formatDate(value) {
+    if (!value) return ''
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? String(value) : date.toISOString()
+}
+
 function createAuditLogService({repository = null, prisma = null, logger = console} = {}) {
     const auditRepository = repository || createAuditEventRepository(prisma || getPrisma())
 
@@ -32,6 +52,45 @@ function createAuditLogService({repository = null, prisma = null, logger = conso
             logger?.warn?.('[audit] write failed', error)
             return null
         }
+    }
+
+    async function listAuditEvents(filters = {}) {
+        return auditRepository.list(filters || {})
+    }
+
+    async function exportAuditEventsMarkdown(filters = {}) {
+        const rows = await listAuditEvents(filters)
+        const lines = [
+            '# Historique de sécurité',
+            '',
+            `Exporté le ${new Date().toISOString()}`,
+            '',
+            '| Date | Type | Sévérité | Domaine | Statut | Résumé |',
+            '| --- | --- | --- | --- | --- | --- |',
+        ]
+        for (const row of rows) {
+            lines.push(`| ${formatDate(row.timestamp)} | ${row.eventType} | ${row.severity} | ${row.domain} | ${row.status} | ${(row.summary || '').replace(/\|/g, '\\|')} |`)
+        }
+        return lines.join('\n')
+    }
+
+    async function exportAuditEventsCsv(filters = {}) {
+        const rows = await listAuditEvents(filters)
+        const lines = ['date;type;severity;domain;status;summary;source;entities;metadata']
+        for (const row of rows) {
+            lines.push([
+                formatDate(row.timestamp),
+                row.eventType,
+                row.severity,
+                row.domain,
+                row.status,
+                row.summary,
+                row.source,
+                JSON.stringify(row.entityIds || []),
+                metadataSummary(row.metadata),
+            ].map(csvEscape).join(';'))
+        }
+        return lines.join('\n')
     }
 
     async function logImportApplied(input = {}, options) {
@@ -196,7 +255,10 @@ function createAuditLogService({repository = null, prisma = null, logger = conso
     }
 
     return {
+        exportAuditEventsCsv,
+        exportAuditEventsMarkdown,
         getRetentionPolicy,
+        listAuditEvents,
         logBackupExported,
         logCriticalDelete,
         logImportApplied,

--- a/electron/ipc/registerAuditLogHandlers.js
+++ b/electron/ipc/registerAuditLogHandlers.js
@@ -7,6 +7,9 @@ const AUDIT_LOG_IPC_CHANNELS = Object.freeze({
     RESTORE_DRY_RUN: 'audit:restore:dryRun',
     RESTORE_APPLIED: 'audit:restore:applied',
     RESTORE_FAILED: 'audit:restore:failed',
+    LIST: 'audit:history:list',
+    EXPORT_MARKDOWN: 'audit:history:exportMarkdown',
+    EXPORT_CSV: 'audit:history:exportCsv',
     RETENTION_POLICY: 'audit:retention:policy',
 })
 
@@ -41,6 +44,9 @@ function createAuditLogHandlers({service = createAuditLogService({prisma: getPri
         logRestoreDryRun: (input) => service.logRestoreDryRun(input),
         logRestoreApplied: (input) => service.logRestoreApplied(input),
         logRestoreFailed: (input) => service.logRestoreFailed(input),
+        listAuditEvents: (filters) => service.listAuditEvents(filters),
+        exportAuditEventsMarkdown: (filters) => service.exportAuditEventsMarkdown(filters),
+        exportAuditEventsCsv: (filters) => service.exportAuditEventsCsv(filters),
         getRetentionPolicy: () => service.getRetentionPolicy(),
     }
 }
@@ -52,6 +58,9 @@ function registerAuditLogHandlers({ipc = ipcMain, service = createAuditLogServic
     registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_DRY_RUN, handlers.logRestoreDryRun)
     registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_APPLIED, handlers.logRestoreApplied)
     registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RESTORE_FAILED, handlers.logRestoreFailed)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.LIST, handlers.listAuditEvents)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.EXPORT_MARKDOWN, handlers.exportAuditEventsMarkdown)
+    registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.EXPORT_CSV, handlers.exportAuditEventsCsv)
     registerSafeAuditLogHandler(ipc, AUDIT_LOG_IPC_CHANNELS.RETENTION_POLICY, handlers.getRetentionPolicy)
 
     return handlers

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -130,6 +130,9 @@ contextBridge.exposeInMainWorld('backupEncryption', {
 })
 
 contextBridge.exposeInMainWorld('auditLog', {
+  list: (filters) => ipcRenderer.invoke('audit:history:list', filters),
+  exportMarkdown: (filters) => ipcRenderer.invoke('audit:history:exportMarkdown', filters),
+  exportCsv: (filters) => ipcRenderer.invoke('audit:history:exportCsv', filters),
   logBackupExported: (input) => ipcRenderer.invoke('audit:backup:exported', input),
   logRestoreDryRun: (input) => ipcRenderer.invoke('audit:restore:dryRun', input),
   logRestoreApplied: (input) => ipcRenderer.invoke('audit:restore:applied', input),

--- a/src/components/SecurityHistorySection.vue
+++ b/src/components/SecurityHistorySection.vue
@@ -1,0 +1,304 @@
+<script setup lang="ts">
+import {computed, onMounted, ref} from 'vue'
+
+type AuditSeverity = 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL'
+type AuditStatus = 'SUCCESS' | 'FAILED' | 'CANCELLED' | 'BLOCKED'
+
+interface AuditEventRecord {
+  id: number
+  eventType: string
+  timestamp: string
+  domain: string
+  action: string
+  severity: AuditSeverity | string
+  summary: string
+  entityIds: Array<{type: string; id: string | number}>
+  metadata: Record<string, unknown> | null
+  source: string
+  status: AuditStatus | string
+}
+
+const emit = defineEmits<{
+  (event: 'notice', type: 'success' | 'error', text: string): void
+}>()
+
+const events = ref<AuditEventRecord[]>([])
+const loading = ref(false)
+const errorMessage = ref<string | null>(null)
+const selected = ref<AuditEventRecord | null>(null)
+const filters = ref({
+  from: '',
+  to: '',
+  eventType: '',
+  severity: '',
+  domain: '',
+})
+
+const eventTypeOptions = [
+  'importApplied',
+  'importCancelled',
+  'importFailed',
+  'backupExported',
+  'encryptedBackupExported',
+  'restoreDryRun',
+  'restoreApplied',
+  'restoreFailed',
+  'criticalDelete',
+  'bulkDelete',
+  'secretCreated',
+  'secretDeleted',
+  'integrityCheckFailed',
+  'migrationApplied',
+]
+const severityOptions: AuditSeverity[] = ['INFO', 'WARNING', 'ERROR', 'CRITICAL']
+const domainOptions = ['import', 'backup', 'restore', 'transaction', 'account', 'category', 'budget', 'recurring', 'wealth', 'secret', 'integrity', 'migration', 'system']
+
+const hasFilters = computed(() => Object.values(filters.value).some(Boolean))
+const failureCount = computed(() => events.value.filter((event) => event.status === 'FAILED' || event.status === 'BLOCKED' || event.severity === 'ERROR' || event.severity === 'CRITICAL').length)
+const successCount = computed(() => events.value.filter((event) => event.status === 'SUCCESS').length)
+
+function unwrapIpcResult<T>(result: any, fallback: string): T {
+  if (result && typeof result === 'object' && 'ok' in result) {
+    if (result.ok) return result.data as T
+    throw new Error(result.error?.message || fallback)
+  }
+  return result as T
+}
+
+function queryPayload() {
+  return {
+    ...(filters.value.from ? {from: `${filters.value.from}T00:00:00.000Z`} : {}),
+    ...(filters.value.to ? {to: `${filters.value.to}T23:59:59.999Z`} : {}),
+    ...(filters.value.eventType ? {eventType: filters.value.eventType} : {}),
+    ...(filters.value.severity ? {severity: filters.value.severity} : {}),
+    ...(filters.value.domain ? {domain: filters.value.domain} : {}),
+    limit: 300,
+  }
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('fr-CA', {dateStyle: 'medium', timeStyle: 'short'}).format(date)
+}
+
+function severityClass(severity: string) {
+  switch (severity) {
+    case 'CRITICAL': return 'border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-200'
+    case 'ERROR': return 'border-red-300 bg-red-50 text-red-700 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-200'
+    case 'WARNING': return 'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-200'
+    default: return 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200'
+  }
+}
+
+function statusClass(status: string) {
+  switch (status) {
+    case 'FAILED': return 'text-red-600 dark:text-red-300'
+    case 'BLOCKED': return 'text-amber-600 dark:text-amber-300'
+    case 'CANCELLED': return 'text-slate-500 dark:text-slate-400'
+    default: return 'text-emerald-600 dark:text-emerald-300'
+  }
+}
+
+function redactValue(value: unknown, depth = 0): unknown {
+  if (depth > 4) return '[truncated]'
+  if (value == null || typeof value === 'number' || typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    if (/secret|password|token|api[_-]?key|authorization|bearer|private key/i.test(value)) return '[redacted]'
+    return value.length > 240 ? `${value.slice(0, 240)}…` : value
+  }
+  if (Array.isArray(value)) return value.slice(0, 30).map((item) => redactValue(item, depth + 1))
+  if (typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).slice(0, 30).map(([key, entry]) => {
+      if (/secret|password|token|api[_-]?key|authorization|credential|raw|accountRows|transactionRows|bank|iban|card/i.test(key)) {
+        return [key, '[redacted]']
+      }
+      return [key, redactValue(entry, depth + 1)]
+    }))
+  }
+  return String(value)
+}
+
+const selectedMetadata = computed(() => {
+  if (!selected.value?.metadata) return '{}'
+  return JSON.stringify(redactValue(selected.value.metadata), null, 2)
+})
+
+async function loadEvents() {
+  loading.value = true
+  errorMessage.value = null
+  try {
+    const result = await window.auditLog.list(queryPayload())
+    events.value = unwrapIpcResult<AuditEventRecord[]>(result, 'Impossible de charger l’historique de sécurité.')
+    if (selected.value) {
+      selected.value = events.value.find((event) => event.id === selected.value?.id) || events.value[0] || null
+    }
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Impossible de charger l’historique de sécurité.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function resetFilters() {
+  filters.value = {from: '', to: '', eventType: '', severity: '', domain: ''}
+  void loadEvents()
+}
+
+async function exportAudit(format: 'markdown' | 'csv') {
+  try {
+    const contentResult = format === 'markdown'
+        ? await window.auditLog.exportMarkdown(queryPayload())
+        : await window.auditLog.exportCsv(queryPayload())
+    const content = unwrapIpcResult<string>(contentResult, 'Export impossible.')
+    const saved = await window.file.saveText({
+      title: format === 'markdown' ? 'Exporter l’historique de sécurité Markdown' : 'Exporter l’historique de sécurité CSV',
+      defaultPath: format === 'markdown' ? 'security-history.md' : 'security-history.csv',
+      content,
+      filters: format === 'markdown' ? [{name: 'Markdown', extensions: ['md']}] : [{name: 'CSV', extensions: ['csv']}],
+    })
+    if (!saved?.canceled) emit('notice', 'success', 'Historique de sécurité exporté.')
+  } catch (error) {
+    emit('notice', 'error', error instanceof Error ? error.message : 'Export impossible.')
+  }
+}
+
+onMounted(loadEvents)
+</script>
+
+<template>
+  <section class="space-y-5">
+    <div class="grid gap-4 lg:grid-cols-3">
+      <div class="panel lg:col-span-2">
+        <p class="soft-kicker">Historique de sécurité</p>
+        <h2 class="mt-2 text-2xl font-bold text-slate-900 dark:text-white">Opérations sensibles</h2>
+        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          Consulte les imports appliqués, exports de backup, restaurations, suppressions critiques et erreurs visibles localement.
+        </p>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div class="mini-card">
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Succès</p>
+          <p class="mt-2 text-2xl font-bold text-emerald-600 dark:text-emerald-300">{{ successCount }}</p>
+        </div>
+        <div class="mini-card">
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">À vérifier</p>
+          <p class="mt-2 text-2xl font-bold text-amber-600 dark:text-amber-300">{{ failureCount }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="grid gap-3 md:grid-cols-5">
+        <label class="field-label">
+          Depuis
+          <input v-model="filters.from" type="date" class="input mt-1" />
+        </label>
+        <label class="field-label">
+          Jusqu’à
+          <input v-model="filters.to" type="date" class="input mt-1" />
+        </label>
+        <label class="field-label">
+          Type
+          <select v-model="filters.eventType" class="input mt-1">
+            <option value="">Tous</option>
+            <option v-for="item in eventTypeOptions" :key="item" :value="item">{{ item }}</option>
+          </select>
+        </label>
+        <label class="field-label">
+          Sévérité
+          <select v-model="filters.severity" class="input mt-1">
+            <option value="">Toutes</option>
+            <option v-for="item in severityOptions" :key="item" :value="item">{{ item }}</option>
+          </select>
+        </label>
+        <label class="field-label">
+          Domaine
+          <select v-model="filters.domain" class="input mt-1">
+            <option value="">Tous</option>
+            <option v-for="item in domainOptions" :key="item" :value="item">{{ item }}</option>
+          </select>
+        </label>
+      </div>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <button class="primary-btn" :disabled="loading" @click="loadEvents">Filtrer</button>
+        <button class="ghost-btn" :disabled="!hasFilters" @click="resetFilters">Réinitialiser</button>
+        <button class="ghost-btn" @click="exportAudit('markdown')">Exporter Markdown</button>
+        <button class="ghost-btn" @click="exportAudit('csv')">Exporter CSV</button>
+      </div>
+    </div>
+
+    <div v-if="errorMessage" class="notice notice-error">{{ errorMessage }}</div>
+
+    <div v-else-if="!loading && events.length === 0" class="panel py-10 text-center">
+      <p class="text-lg font-semibold text-slate-800 dark:text-slate-100">Aucun événement de sécurité</p>
+      <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        Les opérations sensibles apparaîtront ici dès qu’elles seront enregistrées localement.
+      </p>
+    </div>
+
+    <div v-else class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
+      <div class="panel overflow-hidden !p-0">
+        <div class="max-h-[42rem] overflow-auto">
+          <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+            <thead class="sticky top-0 bg-slate-50 text-xs uppercase tracking-[0.14em] text-slate-400 dark:bg-slate-900 dark:text-slate-500">
+              <tr>
+                <th class="px-4 py-3 text-left">Date</th>
+                <th class="px-4 py-3 text-left">Type</th>
+                <th class="px-4 py-3 text-left">Sévérité</th>
+                <th class="px-4 py-3 text-left">Domaine</th>
+                <th class="px-4 py-3 text-left">Statut</th>
+                <th class="px-4 py-3 text-left">Résumé</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-800/70">
+              <tr v-if="loading">
+                <td colspan="6" class="px-4 py-8 text-center text-slate-500">Chargement…</td>
+              </tr>
+              <tr
+                  v-for="event in events"
+                  v-else
+                  :key="event.id"
+                  class="cursor-pointer transition hover:bg-slate-50 dark:hover:bg-slate-900/70"
+                  :class="selected?.id === event.id ? 'bg-violet-50/80 dark:bg-violet-950/30' : ''"
+                  @click="selected = event"
+              >
+                <td class="whitespace-nowrap px-4 py-3 text-slate-500 dark:text-slate-400">{{ formatDate(event.timestamp) }}</td>
+                <td class="px-4 py-3 font-medium text-slate-900 dark:text-slate-100">{{ event.eventType }}</td>
+                <td class="px-4 py-3">
+                  <span class="inline-flex rounded-full border px-2 py-1 text-xs font-semibold" :class="severityClass(event.severity)">
+                    {{ event.severity }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-slate-600 dark:text-slate-300">{{ event.domain }}</td>
+                <td class="px-4 py-3 font-semibold" :class="statusClass(event.status)">{{ event.status }}</td>
+                <td class="px-4 py-3 text-slate-600 dark:text-slate-300">{{ event.summary }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <aside class="panel h-fit xl:sticky xl:top-24">
+        <template v-if="selected">
+          <p class="soft-kicker">Détail</p>
+          <h3 class="mt-2 text-lg font-bold text-slate-900 dark:text-white">{{ selected.eventType }}</h3>
+          <dl class="mt-4 space-y-3 text-sm">
+            <div><dt class="field-label">Date</dt><dd>{{ formatDate(selected.timestamp) }}</dd></div>
+            <div><dt class="field-label">Résumé</dt><dd>{{ selected.summary }}</dd></div>
+            <div><dt class="field-label">Domaine / action</dt><dd>{{ selected.domain }} · {{ selected.action }}</dd></div>
+            <div><dt class="field-label">Source</dt><dd>{{ selected.source || 'local' }}</dd></div>
+            <div><dt class="field-label">Entités</dt><dd>{{ selected.entityIds?.length ? selected.entityIds.map((item) => `${item.type}:${item.id}`).join(', ') : '—' }}</dd></div>
+          </dl>
+          <div class="mt-4">
+            <p class="field-label">Métadonnées redacted</p>
+            <pre class="mt-2 max-h-80 overflow-auto rounded-2xl border border-slate-200 bg-slate-950 p-3 text-xs text-slate-100 dark:border-slate-800">{{ selectedMetadata }}</pre>
+          </div>
+        </template>
+        <template v-else>
+          <p class="text-sm text-slate-500 dark:text-slate-400">Sélectionne un événement pour afficher ses détails.</p>
+        </template>
+      </aside>
+    </div>
+  </section>
+</template>

--- a/src/test/components/SecurityHistorySection.test.ts
+++ b/src/test/components/SecurityHistorySection.test.ts
@@ -1,0 +1,156 @@
+import {mount} from '@vue/test-utils'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import SecurityHistorySection from '../../components/SecurityHistorySection.vue'
+
+function ok<T>(data: T) {
+    return {ok: true, data, error: null}
+}
+
+const auditEvents = [
+    {
+        id: 1,
+        eventType: 'restoreFailed',
+        timestamp: '2026-05-10T02:00:00.000Z',
+        domain: 'restore',
+        action: 'apply',
+        severity: 'ERROR',
+        summary: 'Restauration échouée.',
+        entityIds: [{type: 'file', id: 'backup.json'}],
+        metadata: {
+            reason: 'missing account',
+            password: 'should-redact',
+            nested: {token: 'should-redact-too', safe: 'visible'},
+        },
+        source: 'restore-flow',
+        status: 'FAILED',
+    },
+    {
+        id: 2,
+        eventType: 'backupExported',
+        timestamp: '2026-05-09T12:00:00.000Z',
+        domain: 'backup',
+        action: 'exportJson',
+        severity: 'INFO',
+        summary: 'Backup JSON exporté.',
+        entityIds: [{type: 'file', id: 'budget-backup.json'}],
+        metadata: {format: 'json'},
+        source: 'backup-flow',
+        status: 'SUCCESS',
+    },
+]
+
+function mockWindowApis() {
+    Object.defineProperty(window, 'auditLog', {
+        configurable: true,
+        value: {
+            list: vi.fn().mockResolvedValue(ok(auditEvents)),
+            exportMarkdown: vi.fn().mockResolvedValue(ok('# Historique de sécurité')),
+            exportCsv: vi.fn().mockResolvedValue(ok('date;type')),
+        },
+    })
+    Object.defineProperty(window, 'file', {
+        configurable: true,
+        value: {
+            saveText: vi.fn().mockResolvedValue({canceled: false, filePath: '/tmp/security-history.md'}),
+        },
+    })
+}
+
+describe('SecurityHistorySection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockWindowApis()
+    })
+
+    it('loads security history and displays failed events clearly', async () => {
+        const wrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await wrapper.vm.$nextTick()
+
+        expect(window.auditLog.list).toHaveBeenCalledWith(expect.objectContaining({limit: 300}))
+        expect(wrapper.text()).toContain('Historique de sécurité')
+        expect(wrapper.text()).toContain('restoreFailed')
+        expect(wrapper.text()).toContain('FAILED')
+        expect(wrapper.text()).toContain('Backup JSON exporté')
+        expect(wrapper.text()).toContain('À vérifier')
+        wrapper.unmount()
+    })
+
+    it('applies filters through the audit bridge', async () => {
+        const wrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await wrapper.vm.$nextTick()
+
+        const selects = wrapper.findAll('select.input')
+        await selects[0].setValue('restoreFailed')
+        await selects[1].setValue('ERROR')
+        await selects[2].setValue('restore')
+        const filterButton = wrapper.findAll('button').find((button) => button.text() === 'Filtrer')
+        await filterButton!.trigger('click')
+
+        expect(window.auditLog.list).toHaveBeenLastCalledWith(expect.objectContaining({
+            eventType: 'restoreFailed',
+            severity: 'ERROR',
+            domain: 'restore',
+            limit: 300,
+        }))
+        wrapper.unmount()
+    })
+
+    it('shows redacted event details', async () => {
+        const wrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await wrapper.vm.$nextTick()
+
+        await wrapper.find('tbody tr').trigger('click')
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.text()).toContain('Métadonnées redacted')
+        expect(wrapper.text()).toContain('[redacted]')
+        expect(wrapper.text()).not.toContain('should-redact')
+        expect(wrapper.text()).not.toContain('should-redact-too')
+        expect(wrapper.text()).toContain('visible')
+        wrapper.unmount()
+    })
+
+    it('exports markdown and csv history files', async () => {
+        const wrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await wrapper.vm.$nextTick()
+
+        const markdownButton = wrapper.findAll('button').find((button) => button.text() === 'Exporter Markdown')
+        await markdownButton!.trigger('click')
+        await vi.dynamicImportSettled()
+        expect(window.auditLog.exportMarkdown).toHaveBeenCalledWith(expect.objectContaining({limit: 300}))
+        expect(window.file.saveText).toHaveBeenCalledWith(expect.objectContaining({
+            defaultPath: 'security-history.md',
+            content: '# Historique de sécurité',
+        }))
+
+        const csvButton = wrapper.findAll('button').find((button) => button.text() === 'Exporter CSV')
+        await csvButton!.trigger('click')
+        await vi.dynamicImportSettled()
+        expect(window.auditLog.exportCsv).toHaveBeenCalledWith(expect.objectContaining({limit: 300}))
+        expect(window.file.saveText).toHaveBeenCalledWith(expect.objectContaining({
+            defaultPath: 'security-history.csv',
+            content: 'date;type',
+        }))
+        wrapper.unmount()
+    })
+
+    it('renders empty and error states', async () => {
+        window.auditLog.list = vi.fn().mockResolvedValueOnce(ok([]))
+        const emptyWrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await emptyWrapper.vm.$nextTick()
+        expect(emptyWrapper.text()).toContain('Aucun événement de sécurité')
+        emptyWrapper.unmount()
+
+        window.auditLog.list = vi.fn().mockResolvedValueOnce({ok: false, data: null, error: {message: 'db unavailable'}})
+        const errorWrapper = mount(SecurityHistorySection, {attachTo: document.body})
+        await vi.dynamicImportSettled()
+        await errorWrapper.vm.$nextTick()
+        expect(errorWrapper.text()).toContain('db unavailable')
+        errorWrapper.unmount()
+    })
+})

--- a/src/test/electron/auditLogIpc.test.js
+++ b/src/test/electron/auditLogIpc.test.js
@@ -44,6 +44,9 @@ describe('audit log IPC handlers', () => {
             logRestoreDryRun: vi.fn(async () => ({id: 2, eventType: 'restoreDryRun'})),
             logRestoreApplied: vi.fn(async () => ({id: 3, eventType: 'restoreApplied'})),
             logRestoreFailed: vi.fn(async () => ({id: 4, eventType: 'restoreFailed'})),
+            listAuditEvents: vi.fn(async () => []),
+            exportAuditEventsMarkdown: vi.fn(async () => '# Historique de sécurité'),
+            exportAuditEventsCsv: vi.fn(async () => 'date;type'),
             getRetentionPolicy: vi.fn(() => ({mode: 'keep-all', purgeSupported: false})),
         }
 
@@ -54,6 +57,9 @@ describe('audit log IPC handlers', () => {
             AUDIT_LOG_IPC_CHANNELS.RESTORE_DRY_RUN,
             AUDIT_LOG_IPC_CHANNELS.RESTORE_APPLIED,
             AUDIT_LOG_IPC_CHANNELS.RESTORE_FAILED,
+            AUDIT_LOG_IPC_CHANNELS.LIST,
+            AUDIT_LOG_IPC_CHANNELS.EXPORT_MARKDOWN,
+            AUDIT_LOG_IPC_CHANNELS.EXPORT_CSV,
             AUDIT_LOG_IPC_CHANNELS.RETENTION_POLICY,
         ]))
         expect([...handlers.keys()]).not.toContain('audit:raw:create')
@@ -66,6 +72,35 @@ describe('audit log IPC handlers', () => {
         expect(service.logBackupExported).toHaveBeenCalledWith({encrypted: true, filePath: '/tmp/backup.enc.json'})
     })
 
+    it('lists and exports audit history through dedicated channels', async () => {
+        installElectronMock()
+        const {AUDIT_LOG_IPC_CHANNELS, registerAuditLogHandlers} = require('../../../electron/ipc/registerAuditLogHandlers')
+        const service = {
+            logBackupExported: vi.fn(),
+            logRestoreDryRun: vi.fn(),
+            logRestoreApplied: vi.fn(),
+            logRestoreFailed: vi.fn(),
+            listAuditEvents: vi.fn(async () => [{id: 1, eventType: 'restoreFailed'}]),
+            exportAuditEventsMarkdown: vi.fn(async () => '# Historique de sécurité'),
+            exportAuditEventsCsv: vi.fn(async () => 'date;type'),
+            getRetentionPolicy: vi.fn(),
+        }
+
+        registerAuditLogHandlers({ipc, service})
+        const filters = {eventType: 'restoreFailed', severity: 'ERROR', limit: 100}
+
+        const listed = await handlers.get(AUDIT_LOG_IPC_CHANNELS.LIST)({}, filters)
+        const markdown = await handlers.get(AUDIT_LOG_IPC_CHANNELS.EXPORT_MARKDOWN)({}, filters)
+        const csv = await handlers.get(AUDIT_LOG_IPC_CHANNELS.EXPORT_CSV)({}, filters)
+
+        expect(listed).toEqual({ok: true, data: [{id: 1, eventType: 'restoreFailed'}], error: null})
+        expect(markdown).toEqual({ok: true, data: '# Historique de sécurité', error: null})
+        expect(csv).toEqual({ok: true, data: 'date;type', error: null})
+        expect(service.listAuditEvents).toHaveBeenCalledWith(filters)
+        expect(service.exportAuditEventsMarkdown).toHaveBeenCalledWith(filters)
+        expect(service.exportAuditEventsCsv).toHaveBeenCalledWith(filters)
+    })
+
     it('returns structured IPC errors without throwing into renderer', async () => {
         installElectronMock()
         const {AUDIT_LOG_IPC_CHANNELS, registerAuditLogHandlers} = require('../../../electron/ipc/registerAuditLogHandlers')
@@ -74,6 +109,9 @@ describe('audit log IPC handlers', () => {
             logRestoreDryRun: vi.fn(),
             logRestoreApplied: vi.fn(),
             logRestoreFailed: vi.fn(),
+            listAuditEvents: vi.fn(),
+            exportAuditEventsMarkdown: vi.fn(),
+            exportAuditEventsCsv: vi.fn(),
             getRetentionPolicy: vi.fn(),
         }
 

--- a/src/test/electron/auditLogService.test.js
+++ b/src/test/electron/auditLogService.test.js
@@ -26,6 +26,43 @@ describe('AuditLogService', () => {
         expect(repository.create).toHaveBeenNthCalledWith(6, expect.objectContaining({eventType: 'criticalDelete', domain: 'transaction'}))
     })
 
+    it('lists events and exports markdown/csv history', async () => {
+        const {createAuditLogService} = loadAuditLogService()
+        const rows = [
+            {
+                id: 1,
+                eventType: 'restoreFailed',
+                timestamp: '2026-05-10T02:00:00.000Z',
+                domain: 'restore',
+                action: 'apply',
+                severity: 'ERROR',
+                summary: 'Restore review needed | visible marker',
+                entityIds: [{type: 'file', id: 'backup.json'}],
+                metadata: {reason: 'reference mismatch', count: 2},
+                source: 'restore-flow',
+                status: 'FAILED',
+            },
+        ]
+        const repository = {
+            create: vi.fn(),
+            list: vi.fn(async () => rows),
+        }
+        const service = createAuditLogService({repository, logger: {warn: vi.fn()}})
+        const filters = {eventType: 'restoreFailed', limit: 10}
+
+        await expect(service.listAuditEvents(filters)).resolves.toBe(rows)
+        const markdown = await service.exportAuditEventsMarkdown(filters)
+        const csv = await service.exportAuditEventsCsv(filters)
+
+        expect(repository.list).toHaveBeenCalledWith(filters)
+        expect(markdown).toContain('# Historique de sécurité')
+        expect(markdown).toContain('restoreFailed')
+        expect(markdown).toContain('Restore review needed \\| visible marker')
+        expect(csv).toContain('date;type;severity;domain;status;summary;source;entities;metadata')
+        expect(csv).toContain('restoreFailed')
+        expect(csv).toContain('reference mismatch')
+    })
+
     it('does not break non-strict operations when audit persistence fails', async () => {
         const {createAuditLogService} = loadAuditLogService()
         const logger = {warn: vi.fn()}

--- a/src/types/audit-window.d.ts
+++ b/src/types/audit-window.d.ts
@@ -1,0 +1,24 @@
+import type {AuditEventListFilters, AuditEventRecord} from './audit'
+
+type AuditIpcResult<T> = {
+    ok: boolean
+    data: T | null
+    error: {code: string; message: string} | null
+}
+
+declare global {
+    interface Window {
+        auditLog: {
+            list: (filters?: AuditEventListFilters) => Promise<AuditIpcResult<AuditEventRecord[]>>
+            exportMarkdown: (filters?: AuditEventListFilters) => Promise<AuditIpcResult<string>>
+            exportCsv: (filters?: AuditEventListFilters) => Promise<AuditIpcResult<string>>
+            logBackupExported: (input: Record<string, unknown>) => Promise<AuditIpcResult<AuditEventRecord | null>>
+            logRestoreDryRun: (input: Record<string, unknown>) => Promise<AuditIpcResult<AuditEventRecord | null>>
+            logRestoreApplied: (input: Record<string, unknown>) => Promise<AuditIpcResult<AuditEventRecord | null>>
+            logRestoreFailed: (input: Record<string, unknown>) => Promise<AuditIpcResult<AuditEventRecord | null>>
+            getRetentionPolicy: () => Promise<AuditIpcResult<{mode: string; purgeSupported: boolean; description: string}>>
+        }
+    }
+}
+
+export {}


### PR DESCRIPTION
## Summary

- add audit history list/export support to `AuditLogService`
- expose dedicated IPC handlers for filtered audit history reads and Markdown/CSV exports
- expose `window.auditLog.list/exportMarkdown/exportCsv` through preload
- add `SecurityHistorySection.vue` with:
  - event list table
  - date/type/severity/domain filters
  - empty state
  - error state
  - event detail panel
  - redacted metadata rendering
  - Markdown/CSV export buttons
- add TS bridge types for audit history
- add unit/component tests for IPC, exports, filters, detail rendering, redaction, empty/error states

Closes #93.

## Important note

The standalone section and bridge are implemented and tested, but I did not patch `src/App.vue` in this environment because the GitHub tool repeatedly returned/truncated the large file content and I did not want to risk replacing the app shell incorrectly. To make the section visible from the sidebar, the remaining integration is small:

- import `SecurityHistorySection` in `App.vue`
- add a `securityHistory` section key/nav entry
- render `<SecurityHistorySection @notice="showNotice" />` when that section is active

## Testing

- Not run locally in this environment.
- Added/updated targeted tests:
  - `src/test/components/SecurityHistorySection.test.ts`
  - `src/test/electron/auditLogIpc.test.js`
  - `src/test/electron/auditLogService.test.js`