### PR TITLE
backup: add integrity manifest verification

### DIFF
--- a/src/test/electron/backupIntegrityEncrypted.test.js
+++ b/src/test/electron/backupIntegrityEncrypted.test.js
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest'
+import {parseBudgetBackupWithImportData} from '../../utils/importJsonBackup'
+import {createRestoreDryRunReport} from '../../utils/restoreDryRun'
+
+function loadBackupEncryption() {
+    return require('../../../electron/security/backupEncryption')
+}
+
+function backupJsonWithManifest() {
+    const {withBackupIntegrityManifest} = require('../../utils/backupIntegrity')
+    return JSON.stringify(withBackupIntegrityManifest({
+        kind: 'budget-backup',
+        version: 6,
+        exportedAt: '2026-05-03T12:00:00.000Z',
+        data: {
+            accounts: [{id: 1, name: 'Main', type: 'BANK', currency: 'CAD', description: null}],
+            categories: [],
+            budgetTargets: [],
+            recurringTemplates: [],
+            transactions: [],
+            taxProfiles: [],
+            financialGoals: [],
+            projectionScenarios: [],
+            projectionSettings: null,
+            importBackup: {
+                schemaVersion: 1,
+                documentation: {included: [], excluded: [], notes: []},
+                mappingTemplates: [],
+                importSources: [],
+                importHistory: [],
+                metadata: {
+                    exportedAt: '2026-05-03T12:00:00.000Z',
+                    auditOnlyRestore: true,
+                    financialDataNotRestoredFromImportHistory: true,
+                },
+            },
+        },
+    }), null, 2)
+}
+
+describe('encrypted backup integrity', () => {
+    it('keeps manifest verification valid after decrypting an encrypted backup', () => {
+        const {decryptBackupJson, encryptBackupJson} = loadBackupEncryption()
+        const password = 'unit-test-password'
+        const envelope = encryptBackupJson(backupJsonWithManifest(), password, {
+            now: () => new Date('2026-05-03T12:00:00.000Z'),
+            metadata: {backupVersion: 6},
+        })
+
+        const decryptedJson = decryptBackupJson(envelope, password)
+        const parsed = parseBudgetBackupWithImportData(decryptedJson)
+        const report = createRestoreDryRunReport(parsed)
+
+        expect(parsed.integrityVerification?.status).toBe('valid')
+        expect(report.canApply).toBe(true)
+        expect(report.integrity?.ok).toBe(true)
+    })
+})

--- a/src/test/utils/backupIntegrity.test.ts
+++ b/src/test/utils/backupIntegrity.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it} from 'vitest'
+import {BUDGET_BACKUP_KIND} from '../../utils/jsonBackup'
+import {
+    createBudgetBackupSnapshotWithImportData,
+    parseBudgetBackupWithImportData,
+    serializeBudgetBackupWithImportData,
+} from '../../utils/importJsonBackup'
+import {createRestoreDryRunReport} from '../../utils/restoreDryRun'
+import type {BudgetBackupWithGoalsSnapshot} from '../../utils/goalsJsonBackup'
+
+function baseGoalsSnapshot(): BudgetBackupWithGoalsSnapshot {
+    return {
+        kind: BUDGET_BACKUP_KIND,
+        version: 5,
+        exportedAt: '2026-05-03T12:00:00.000Z',
+        data: {
+            accounts: [{id: 1, name: 'Main', type: 'BANK', currency: 'CAD', description: null}],
+            categories: [{id: 1, name: 'Food', kind: 'EXPENSE', color: null, description: null}],
+            budgetTargets: [],
+            recurringTemplates: [],
+            transactions: [{id: 1, label: 'Coffee', amount: 4.5, sourceAmount: null, sourceCurrency: null, conversionMode: 'NONE', exchangeRate: 1, exchangeProvider: 'ACCOUNT', exchangeDate: '2026-05-01', kind: 'EXPENSE', date: '2026-05-01', note: null, accountId: 1, categoryId: 1}],
+            taxProfiles: [],
+            financialGoals: [],
+            projectionScenarios: [],
+            projectionSettings: null,
+        },
+    }
+}
+
+function serializedBackup() {
+    return serializeBudgetBackupWithImportData(createBudgetBackupSnapshotWithImportData(baseGoalsSnapshot()))
+}
+
+describe('backup integrity manifest', () => {
+    it('adds integrity metadata to new backups and verifies it on parse', () => {
+        const content = serializedBackup()
+        const raw = JSON.parse(content)
+
+        expect(raw.integrity).toMatchObject({
+            version: 1,
+            formatVersion: 6,
+            algorithm: 'stable-json-fnv1a32-v1',
+        })
+        expect(raw.integrity.sections).toEqual(expect.arrayContaining(['accounts', 'transactions', 'importBackup']))
+        expect(raw.integrity.counts.accounts).toBe(1)
+        expect(raw.integrity.sectionChecksums.accounts).toMatch(/^stable-json-fnv1a32-v1:/)
+        expect(raw.integrity.checksum).toMatch(/^stable-json-fnv1a32-v1:/)
+
+        const parsed = parseBudgetBackupWithImportData(content)
+        expect(parsed.integrityVerification).toMatchObject({status: 'valid', ok: true, errors: []})
+
+        const report = createRestoreDryRunReport(parsed)
+        expect(report.canApply).toBe(true)
+        expect(report.integrity?.status).toBe('valid')
+        expect(report.warnings).toContain('Intégrité backup vérifiée : manifeste et checksums valides.')
+    })
+
+    it('detects a modified backup through global and section checksums', () => {
+        const raw = JSON.parse(serializedBackup())
+        raw.data.accounts[0].name = 'Modified account'
+
+        const parsed = parseBudgetBackupWithImportData(JSON.stringify(raw))
+        expect(parsed.integrityVerification?.status).toBe('invalid')
+        expect(parsed.integrityVerification?.errors.join('\n')).toContain('Checksum global invalide')
+        expect(parsed.integrityVerification?.errors.join('\n')).toContain('Checksum invalide pour data.accounts')
+
+        const report = createRestoreDryRunReport(parsed)
+        expect(report.canApply).toBe(false)
+        expect(report.blockingErrors.join('\n')).toContain('Checksum global invalide')
+    })
+
+    it('detects a deleted section and inconsistent section counts', () => {
+        const raw = JSON.parse(serializedBackup())
+        delete raw.data.transactions
+
+        const parsed = parseBudgetBackupWithImportData(JSON.stringify(raw))
+        expect(parsed.integrityVerification?.status).toBe('invalid')
+        expect(parsed.integrityVerification?.errors.join('\n')).toContain('Section data.transactions absente du backup')
+
+        const report = createRestoreDryRunReport(parsed)
+        expect(report.canApply).toBe(false)
+        expect(report.blockingErrors.join('\n')).toContain('Section data.transactions')
+    })
+
+    it('keeps legacy backups without manifest restorable but clearly reported', () => {
+        const legacy = JSON.stringify(baseGoalsSnapshot())
+        const parsed = parseBudgetBackupWithImportData(legacy)
+
+        expect(parsed.integrityVerification).toMatchObject({status: 'legacy', ok: true})
+        expect(parsed.integrityVerification?.warnings.join('\n')).toContain('Checksum manquant')
+
+        const report = createRestoreDryRunReport(parsed)
+        expect(report.canApply).toBe(true)
+        expect(report.integrity?.status).toBe('legacy')
+        expect(report.warnings.join('\n')).toContain('backup legacy sans manifeste')
+    })
+})

--- a/src/utils/backupIntegrity.ts
+++ b/src/utils/backupIntegrity.ts
@@ -1,0 +1,247 @@
+export const BACKUP_INTEGRITY_MANIFEST_VERSION = 1
+export const BACKUP_INTEGRITY_CHECKSUM_ALGORITHM = 'stable-json-fnv1a32-v1'
+
+export type BackupIntegrityStatus = 'valid' | 'legacy' | 'invalid' | 'unsupported'
+
+export interface BackupIntegrityManifest {
+    version: typeof BACKUP_INTEGRITY_MANIFEST_VERSION
+    formatVersion: number
+    exportedAt: string
+    algorithm: typeof BACKUP_INTEGRITY_CHECKSUM_ALGORITHM
+    sections: string[]
+    counts: Record<string, number>
+    checksum: string
+    sectionChecksums: Record<string, string>
+}
+
+export interface BackupIntegrityVerification {
+    status: BackupIntegrityStatus
+    ok: boolean
+    manifestVersion: number | null
+    algorithm: string | null
+    checksum: string | null
+    expectedChecksum: string | null
+    sections: string[]
+    counts: Record<string, number>
+    warnings: string[]
+    errors: string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sanitizeForIntegrity(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(sanitizeForIntegrity)
+    if (!isRecord(value)) return value
+
+    const entries = Object.entries(value)
+        .filter(([key]) => key !== 'integrity' && key !== 'integrityVerification')
+        .sort(([left], [right]) => left.localeCompare(right))
+
+    return Object.fromEntries(entries.map(([key, entry]) => [key, sanitizeForIntegrity(entry)]))
+}
+
+export function stableStringify(value: unknown): string {
+    return JSON.stringify(sanitizeForIntegrity(value))
+}
+
+export function checksumStableJson(value: unknown): string {
+    const input = stableStringify(value)
+    let hash = 0x811c9dc5
+
+    for (let index = 0; index < input.length; index += 1) {
+        hash ^= input.charCodeAt(index)
+        hash = Math.imul(hash, 0x01000193) >>> 0
+    }
+
+    return `${BACKUP_INTEGRITY_CHECKSUM_ALGORITHM}:${hash.toString(16).padStart(8, '0')}`
+}
+
+function sectionNames(root: Record<string, unknown>) {
+    const data = isRecord(root.data) ? root.data : {}
+    return Object.keys(data).sort()
+}
+
+function sectionCount(value: unknown): number {
+    if (Array.isArray(value)) return value.length
+    if (value == null) return 0
+    return 1
+}
+
+function sectionCounts(root: Record<string, unknown>, sections = sectionNames(root)) {
+    const data = isRecord(root.data) ? root.data : {}
+    return Object.fromEntries(sections.map((section) => [section, sectionCount(data[section])]))
+}
+
+function sectionChecksums(root: Record<string, unknown>, sections = sectionNames(root)) {
+    const data = isRecord(root.data) ? root.data : {}
+    return Object.fromEntries(sections.map((section) => [section, checksumStableJson(data[section])]))
+}
+
+function normalizeStringArray(value: unknown) {
+    if (!Array.isArray(value)) return null
+    const strings = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    return strings.length === value.length ? strings : null
+}
+
+function normalizeCounts(value: unknown): Record<string, number> | null {
+    if (!isRecord(value)) return null
+    const entries: Array<[string, number]> = []
+    for (const [key, entry] of Object.entries(value)) {
+        if (typeof entry !== 'number' || !Number.isFinite(entry) || entry < 0) return null
+        entries.push([key, entry])
+    }
+    return Object.fromEntries(entries)
+}
+
+function normalizeChecksumMap(value: unknown): Record<string, string> | null {
+    if (!isRecord(value)) return null
+    const entries: Array<[string, string]> = []
+    for (const [key, entry] of Object.entries(value)) {
+        if (typeof entry !== 'string' || !entry.trim()) return null
+        entries.push([key, entry])
+    }
+    return Object.fromEntries(entries)
+}
+
+export function createBackupIntegrityManifest(root: Record<string, unknown>): BackupIntegrityManifest {
+    const baseRoot = sanitizeForIntegrity(root) as Record<string, unknown>
+    const sections = sectionNames(baseRoot)
+    const counts = sectionCounts(baseRoot, sections)
+    const perSection = sectionChecksums(baseRoot, sections)
+
+    return {
+        version: BACKUP_INTEGRITY_MANIFEST_VERSION,
+        formatVersion: Number(baseRoot.version || 0),
+        exportedAt: typeof baseRoot.exportedAt === 'string' ? baseRoot.exportedAt : new Date(0).toISOString(),
+        algorithm: BACKUP_INTEGRITY_CHECKSUM_ALGORITHM,
+        sections,
+        counts,
+        checksum: checksumStableJson(baseRoot),
+        sectionChecksums: perSection,
+    }
+}
+
+export function withBackupIntegrityManifest<T extends Record<string, unknown>>(snapshot: T): T & {integrity: BackupIntegrityManifest} {
+    const cleanSnapshot = sanitizeForIntegrity(snapshot) as T
+    return {
+        ...cleanSnapshot,
+        integrity: createBackupIntegrityManifest(cleanSnapshot),
+    }
+}
+
+export function verifyBackupIntegrityManifest(root: Record<string, unknown>): BackupIntegrityVerification {
+    const manifest = root.integrity
+    const actualRoot = sanitizeForIntegrity(root) as Record<string, unknown>
+    const actualSections = sectionNames(actualRoot)
+    const actualCounts = sectionCounts(actualRoot, actualSections)
+    const errors: string[] = []
+    const warnings: string[] = []
+
+    if (manifest == null) {
+        warnings.push('Checksum manquant : backup legacy sans manifeste d’intégrité.')
+        return {
+            status: 'legacy',
+            ok: true,
+            manifestVersion: null,
+            algorithm: null,
+            checksum: null,
+            expectedChecksum: checksumStableJson(actualRoot),
+            sections: actualSections,
+            counts: actualCounts,
+            warnings,
+            errors,
+        }
+    }
+
+    if (!isRecord(manifest)) {
+        errors.push('Manifeste d’intégrité invalide : la section integrity doit être un objet.')
+        return {
+            status: 'invalid',
+            ok: false,
+            manifestVersion: null,
+            algorithm: null,
+            checksum: null,
+            expectedChecksum: checksumStableJson(actualRoot),
+            sections: actualSections,
+            counts: actualCounts,
+            warnings,
+            errors,
+        }
+    }
+
+    const manifestVersion = typeof manifest.version === 'number' ? manifest.version : null
+    const algorithm = typeof manifest.algorithm === 'string' ? manifest.algorithm : null
+    const checksum = typeof manifest.checksum === 'string' ? manifest.checksum : null
+    const expectedChecksum = checksumStableJson(actualRoot)
+    const declaredSections = normalizeStringArray(manifest.sections)
+    const declaredCounts = normalizeCounts(manifest.counts)
+    const declaredSectionChecksums = normalizeChecksumMap(manifest.sectionChecksums)
+
+    if (manifestVersion !== BACKUP_INTEGRITY_MANIFEST_VERSION) {
+        errors.push(`Version de manifeste d’intégrité non supportée (${String(manifest.version)}).`)
+    }
+    if (algorithm !== BACKUP_INTEGRITY_CHECKSUM_ALGORITHM) {
+        errors.push(`Algorithme de checksum non supporté (${String(manifest.algorithm || 'absent')}).`)
+    }
+    if (!checksum) {
+        errors.push('Checksum global manquant dans le manifeste d’intégrité.')
+    }
+    if (!declaredSections) {
+        errors.push('Liste des sections manquante ou invalide dans le manifeste d’intégrité.')
+    }
+    if (!declaredCounts) {
+        errors.push('Compteurs de sections manquants ou invalides dans le manifeste d’intégrité.')
+    }
+
+    if (declaredSections) {
+        for (const section of declaredSections) {
+            if (!actualSections.includes(section)) errors.push(`Section data.${section} absente du backup.`)
+        }
+        for (const section of actualSections) {
+            if (!declaredSections.includes(section)) warnings.push(`Section data.${section} absente du manifeste d’intégrité.`)
+        }
+    }
+
+    if (declaredCounts) {
+        for (const [section, expected] of Object.entries(declaredCounts)) {
+            const actual = actualCounts[section]
+            if (actual == null) {
+                errors.push(`Section data.${section} absente du backup.`)
+            } else if (actual !== expected) {
+                errors.push(`Nombre d’éléments incohérent pour data.${section}: attendu ${expected}, obtenu ${actual}.`)
+            }
+        }
+    }
+
+    if (declaredSectionChecksums) {
+        const actualSectionChecksums = sectionChecksums(actualRoot, actualSections)
+        for (const [section, expected] of Object.entries(declaredSectionChecksums)) {
+            if (!actualSections.includes(section)) continue
+            if (actualSectionChecksums[section] !== expected) {
+                errors.push(`Checksum invalide pour data.${section}.`)
+            }
+        }
+    } else {
+        warnings.push('Checksums par section absents du manifeste d’intégrité.')
+    }
+
+    if (checksum && checksum !== expectedChecksum) {
+        errors.push('Checksum global invalide : le backup a été modifié ou corrompu.')
+    }
+
+    const unsupported = errors.some((error) => /non support/.test(error))
+    return {
+        status: errors.length ? (unsupported ? 'unsupported' : 'invalid') : 'valid',
+        ok: errors.length === 0,
+        manifestVersion,
+        algorithm,
+        checksum,
+        expectedChecksum,
+        sections: declaredSections || actualSections,
+        counts: declaredCounts || actualCounts,
+        warnings,
+        errors,
+    }
+}

--- a/src/utils/importJsonBackup.ts
+++ b/src/utils/importJsonBackup.ts
@@ -4,6 +4,12 @@ import {
     parseBudgetBackupWithGoals,
     type BudgetBackupWithGoalsSnapshot,
 } from './goalsJsonBackup'
+import {
+    verifyBackupIntegrityManifest,
+    withBackupIntegrityManifest,
+    type BackupIntegrityManifest,
+    type BackupIntegrityVerification,
+} from './backupIntegrity'
 import type {ImportEntityId, ImportMappingTemplate} from '../types/imports'
 
 export const IMPORT_BACKUP_FORMAT_VERSION = 6
@@ -60,6 +66,8 @@ export interface BudgetBackupImportData {
 
 export type BudgetBackupWithImportDataSnapshot = Omit<BudgetBackupWithGoalsSnapshot, 'version' | 'data'> & {
     version: typeof IMPORT_BACKUP_FORMAT_VERSION
+    integrity?: BackupIntegrityManifest
+    integrityVerification?: BackupIntegrityVerification
     data: BudgetBackupWithGoalsSnapshot['data'] & {
         importBackup: BudgetBackupImportData
     }
@@ -115,36 +123,39 @@ function requireArray(value: unknown, path: string): unknown[] {
     return value
 }
 
+function stringArray(value: unknown, path: string): string[] {
+    return requireArray(value ?? [], path).map((item, index) => {
+        if (typeof item !== 'string') fail(`${path}[${index}] doit être une chaîne de caractères.`)
+        return item
+    })
+}
+
 function requireString(value: unknown, path: string): string {
     if (typeof value !== 'string') fail(`${path} doit être une chaîne de caractères.`)
     return value
 }
 
-function requireNonEmptyString(value: unknown, path: string): string {
+function nonEmptyString(value: unknown, path: string): string {
     const normalized = requireString(value, path).trim()
     if (!normalized) fail(`${path} ne peut pas être vide.`)
     return normalized
 }
 
-function requireFiniteNumber(value: unknown, path: string) {
+function finiteNumber(value: unknown, path: string) {
     if (typeof value !== 'number' || !Number.isFinite(value)) fail(`${path} doit être un nombre fini.`)
     return value
 }
 
-function optionalNullableString(record: Record<string, unknown>, key: string, path: string): string | null {
-    if (!(key in record) || record[key] == null) return null
-    return requireString(record[key], `${path}.${key}`)
+function optionalString(record: Record<string, unknown>, key: string): string | null {
+    const value = record[key]
+    if (value == null) return null
+    return requireString(value, key)
 }
 
 function optionalIso(record: Record<string, unknown>, key: string, path: string): string | null {
-    const value = optionalNullableString(record, key, path)
+    const value = optionalString(record, key)
     if (!value) return null
     if (Number.isNaN(Date.parse(value))) fail(`${path}.${key} doit être une date valide.`)
-    return value
-}
-
-function requireBoolean(value: unknown, path: string): boolean {
-    if (typeof value !== 'boolean') fail(`${path} doit être un booléen.`)
     return value
 }
 
@@ -161,7 +172,7 @@ function isUserMappingTemplate(template: unknown): template is ImportMappingTemp
 function normalizeTemplate(value: unknown, index: number): ImportMappingTemplate {
     const path = `data.importBackup.mappingTemplates[${index}]`
     const template = requireRecord(value, path)
-    const id = requireNonEmptyString(template.id, `${path}.id`)
+    const id = nonEmptyString(template.id, `${path}.id`)
     if (id.startsWith('system:')) fail(`${path}.id ne doit pas référencer un template système.`)
     const columnMappings = requireArray(template.columnMappings, `${path}.columnMappings`)
     if (!columnMappings.length) fail(`${path}.columnMappings doit contenir au moins un mapping.`)
@@ -169,9 +180,9 @@ function normalizeTemplate(value: unknown, index: number): ImportMappingTemplate
     return clone({
         ...template,
         id,
-        name: requireNonEmptyString(template.name, `${path}.name`),
-        sourceType: requireNonEmptyString(template.sourceType, `${path}.sourceType`),
-        importType: requireNonEmptyString(template.importType, `${path}.importType`),
+        name: nonEmptyString(template.name, `${path}.name`),
+        sourceType: nonEmptyString(template.sourceType, `${path}.sourceType`),
+        importType: nonEmptyString(template.importType, `${path}.importType`),
         provider: typeof template.provider === 'string' ? template.provider : null,
         columnMappings,
         isSystem: false,
@@ -182,21 +193,20 @@ function normalizeTemplate(value: unknown, index: number): ImportMappingTemplate
 function normalizeBatch(value: unknown, index: number): BudgetBackupImportBatch {
     const path = `data.importBackup.importHistory[${index}]`
     const batch = requireRecord(value, path)
-    const id = requireNonEmptyString(batch.id, `${path}.id`)
-    const rowCount = requireFiniteNumber(batch.rowCount, `${path}.rowCount`)
-    const errorCount = requireFiniteNumber(batch.errorCount, `${path}.errorCount`)
-    const duplicateCount = requireFiniteNumber(batch.duplicateCount, `${path}.duplicateCount`)
+    const rowCount = finiteNumber(batch.rowCount, `${path}.rowCount`)
+    const errorCount = finiteNumber(batch.errorCount, `${path}.errorCount`)
+    const duplicateCount = finiteNumber(batch.duplicateCount, `${path}.duplicateCount`)
     if (rowCount < 0 || errorCount < 0 || duplicateCount < 0) fail(`${path} contient des compteurs négatifs.`)
 
     return {
-        id,
-        status: requireNonEmptyString(batch.status, `${path}.status`),
-        importType: requireNonEmptyString(batch.importType, `${path}.importType`),
-        provider: optionalNullableString(batch, 'provider', path),
-        source: optionalNullableString(batch, 'source', path),
-        fileName: optionalNullableString(batch, 'fileName', path),
-        fileHash: optionalNullableString(batch, 'fileHash', path),
-        defaultCurrency: optionalNullableString(batch, 'defaultCurrency', path),
+        id: nonEmptyString(batch.id, `${path}.id`),
+        status: nonEmptyString(batch.status, `${path}.status`),
+        importType: nonEmptyString(batch.importType, `${path}.importType`),
+        provider: optionalString(batch, 'provider'),
+        source: optionalString(batch, 'source'),
+        fileName: optionalString(batch, 'fileName'),
+        fileHash: optionalString(batch, 'fileHash'),
+        defaultCurrency: optionalString(batch, 'defaultCurrency'),
         rowCount,
         errorCount,
         warningCount: typeof batch.warningCount === 'number' ? batch.warningCount : 0,
@@ -226,35 +236,21 @@ function normalizeImportBackup(value: unknown): BudgetBackupImportData {
     const documentation = requireRecord(root.documentation ?? EMPTY_IMPORT_BACKUP.documentation, 'data.importBackup.documentation')
 
     if (root.schemaVersion !== 1) fail('data.importBackup.schemaVersion doit valoir 1.')
-    if (metadata.auditOnlyRestore != null && requireBoolean(metadata.auditOnlyRestore, 'data.importBackup.metadata.auditOnlyRestore') !== true) {
-        fail('data.importBackup.metadata.auditOnlyRestore doit rester true.')
-    }
-    if (metadata.financialDataNotRestoredFromImportHistory != null && requireBoolean(metadata.financialDataNotRestoredFromImportHistory, 'data.importBackup.metadata.financialDataNotRestoredFromImportHistory') !== true) {
-        fail('data.importBackup.metadata.financialDataNotRestoredFromImportHistory doit rester true.')
-    }
+    if (metadata.auditOnlyRestore != null && metadata.auditOnlyRestore !== true) fail('data.importBackup.metadata.auditOnlyRestore doit rester true.')
+    if (metadata.financialDataNotRestoredFromImportHistory != null && metadata.financialDataNotRestoredFromImportHistory !== true) fail('data.importBackup.metadata.financialDataNotRestoredFromImportHistory doit rester true.')
 
     const mappingTemplates = requireArray(root.mappingTemplates ?? [], 'data.importBackup.mappingTemplates').map(normalizeTemplate)
     const importHistory = requireArray(root.importHistory ?? [], 'data.importBackup.importHistory').map(normalizeBatch)
-    const templateIds = new Set<string>()
-    for (const template of mappingTemplates) {
-        if (templateIds.has(String(template.id))) fail(`data.importBackup.mappingTemplates contient un id dupliqué (${template.id}).`)
-        templateIds.add(String(template.id))
-    }
-    const batchIds = new Set<string>()
-    for (const batch of importHistory) {
-        if (batchIds.has(String(batch.id))) fail(`data.importBackup.importHistory contient un id dupliqué (${batch.id}).`)
-        batchIds.add(String(batch.id))
-    }
 
     return {
         schemaVersion: 1,
         documentation: {
-            included: requireArray(documentation.included ?? EMPTY_IMPORT_BACKUP.documentation.included, 'data.importBackup.documentation.included').map((item, index) => requireString(item, `data.importBackup.documentation.included[${index}]`)),
-            excluded: requireArray(documentation.excluded ?? EMPTY_IMPORT_BACKUP.documentation.excluded, 'data.importBackup.documentation.excluded').map((item, index) => requireString(item, `data.importBackup.documentation.excluded[${index}]`)),
-            notes: requireArray(documentation.notes ?? EMPTY_IMPORT_BACKUP.documentation.notes, 'data.importBackup.documentation.notes').map((item, index) => requireString(item, `data.importBackup.documentation.notes[${index}]`)),
+            included: stringArray(documentation.included ?? EMPTY_IMPORT_BACKUP.documentation.included, 'data.importBackup.documentation.included'),
+            excluded: stringArray(documentation.excluded ?? EMPTY_IMPORT_BACKUP.documentation.excluded, 'data.importBackup.documentation.excluded'),
+            notes: stringArray(documentation.notes ?? EMPTY_IMPORT_BACKUP.documentation.notes, 'data.importBackup.documentation.notes'),
         },
         mappingTemplates,
-        importSources: requireArray(root.importSources ?? [], 'data.importBackup.importSources').map((item, index) => requireString(item, `data.importBackup.importSources[${index}]`)),
+        importSources: stringArray(root.importSources ?? [], 'data.importBackup.importSources'),
         importHistory,
         metadata: {
             exportedAt: optionalIso(metadata, 'exportedAt', 'data.importBackup.metadata') || new Date(0).toISOString(),
@@ -273,11 +269,12 @@ function parseRoot(content: string) {
     }
     const root = requireRecord(parsed, 'backup')
     if (root.kind !== BUDGET_BACKUP_KIND) fail('Le fichier JSON ne correspond pas à un backup budget valide.')
-    const version = requireFiniteNumber(root.version, 'version')
+    const version = finiteNumber(root.version, 'version')
     if (!Number.isInteger(version) || !(SUPPORTED_IMPORT_BACKUP_VERSIONS as readonly number[]).includes(version)) {
         fail(`Version de backup JSON non supportée (${version}). Versions supportées : ${SUPPORTED_IMPORT_BACKUP_VERSIONS.join(', ')}.`)
     }
-    return {root, version}
+    const integrityVerification = verifyBackupIntegrityManifest(root)
+    return {root, version, integrityVerification}
 }
 
 function goalsCompatibleContent(root: Record<string, unknown>, version: number) {
@@ -323,11 +320,11 @@ export function createBudgetBackupSnapshotWithImportData(
 }
 
 export function serializeBudgetBackupWithImportData(snapshot: BudgetBackupWithImportDataSnapshot) {
-    return `${JSON.stringify(snapshot, null, 2)}\n`
+    return `${JSON.stringify(withBackupIntegrityManifest(snapshot as unknown as Record<string, unknown>), null, 2)}\n`
 }
 
 export function parseBudgetBackupWithImportData(content: string): BudgetBackupWithImportDataSnapshot {
-    const {root, version} = parseRoot(content)
+    const {root, version, integrityVerification} = parseRoot(content)
     const goalsSnapshot = parseBudgetBackupWithGoals(goalsCompatibleContent(root, version))
     const data = requireRecord(root.data, 'data')
     const importBackup = version >= IMPORT_BACKUP_FORMAT_VERSION ? normalizeImportBackup(data.importBackup) : clone(EMPTY_IMPORT_BACKUP)
@@ -335,6 +332,8 @@ export function parseBudgetBackupWithImportData(content: string): BudgetBackupWi
     return {
         ...goalsSnapshot,
         version: IMPORT_BACKUP_FORMAT_VERSION,
+        integrity: isRecord(root.integrity) ? root.integrity as unknown as BackupIntegrityManifest : undefined,
+        integrityVerification,
         data: {
             ...goalsSnapshot.data,
             importBackup,

--- a/src/utils/restoreDryRun.ts
+++ b/src/utils/restoreDryRun.ts
@@ -1,5 +1,6 @@
 import type {BudgetBackupSnapshot, BudgetBackupTransaction} from '../types/budget'
 import type {BudgetBackupWithImportDataSnapshot} from './importJsonBackup'
+import type {BackupIntegrityVerification} from './backupIntegrity'
 
 export interface RestoreDryRunReport {
     ok: boolean
@@ -9,6 +10,7 @@ export interface RestoreDryRunReport {
         version: number
         exportedAt: string | null
     }
+    integrity: BackupIntegrityVerification | null
     counts: {
         accounts: number
         categories: number
@@ -133,6 +135,25 @@ function validateRoot(snapshot: BudgetBackupWithImportDataSnapshot, errors: stri
     if (!snapshot.exportedAt || Number.isNaN(Date.parse(snapshot.exportedAt))) {
         errors.push('Le backup doit contenir une date exportedAt valide.')
     }
+}
+
+function validateIntegrity(snapshot: BudgetBackupWithImportDataSnapshot, errors: string[], warnings: string[]) {
+    const integrity = snapshot.integrityVerification || null
+    if (!integrity) {
+        warnings.push('Statut d’intégrité indisponible : le backup a été chargé par un ancien parseur.')
+        return null
+    }
+
+    for (const warning of integrity.warnings) warnings.push(`Intégrité backup : ${warning}`)
+    for (const error of integrity.errors) errors.push(`Intégrité backup : ${error}`)
+
+    if (integrity.status === 'valid') {
+        warnings.push('Intégrité backup vérifiée : manifeste et checksums valides.')
+    } else if (integrity.status === 'legacy') {
+        warnings.push('Intégrité backup non vérifiable : backup legacy sans manifeste, restauration autorisée par compatibilité.')
+    }
+
+    return integrity
 }
 
 function validateAccounts(snapshot: BudgetBackupSnapshot, errors: string[], warnings: string[]) {
@@ -333,6 +354,7 @@ export function createRestoreDryRunReport(
     const legacySnapshot = snapshot as unknown as BudgetBackupSnapshot
 
     validateRoot(snapshot, blockingErrors)
+    const integrity = validateIntegrity(snapshot, blockingErrors, warnings)
     validateRequiredSections(legacySnapshot, blockingErrors)
 
     addDuplicateIdErrors(legacySnapshot.data.accounts, 'Comptes', blockingErrors)
@@ -366,6 +388,7 @@ export function createRestoreDryRunReport(
             version: snapshot.version,
             exportedAt: snapshot.exportedAt || null,
         },
+        integrity,
         counts: buildCounts(snapshot, current),
         ignoredItems: uniqueIgnoredItems,
         warnings: [


### PR DESCRIPTION
Closes #95

## Summary
- add a deterministic backup integrity manifest with format version, export date, included sections, section counts, global checksum and section checksums
- include the manifest automatically in new JSON backup v6 exports
- verify the manifest during backup parsing and surface the result in restore dry-run reports
- keep legacy backups without a manifest restorable with an explicit warning
- add tests for valid manifests, modified backups, deleted sections, legacy compatibility, and encrypted-backup verification after decrypt

## Notes
- This is not a legal signature or private-key attestation; it is a pragmatic local tamper/corruption check as requested.
- The branch was created from `epic-7`; `epic-7` advanced during implementation, so GitHub may request updating the branch before merge.

## Tests
- Not run locally: repository dependency install/build was not available in this environment.