### PR TITLE
provenance: add shared freshness metadata model

### DIFF
--- a/src/test/utils/domainProvenance.test.ts
+++ b/src/test/utils/domainProvenance.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'vitest'
+import {
+    attachBackupRestoreProvenance,
+    attachImportedTransactionProvenance,
+    attachMarketSnapshotProvenance,
+    attachProjectionProvenance,
+    attachValuationProvenance,
+} from '../../utils/domainProvenance'
+
+describe('domain provenance adapters', () => {
+    it('links imported transactions to their import batch without storing secrets', () => {
+        const wrapped = attachImportedTransactionProvenance(
+            {id: 1, label: 'Coffee'},
+            {id: 'batch-1', provider: 'bank-a', fileName: 'bank.csv', importedAt: '2026-05-11T10:00:00.000Z'},
+        )
+
+        expect(wrapped.value).toEqual({id: 1, label: 'Coffee'})
+        expect(wrapped.provenance).toMatchObject({
+            origin: 'csvImport',
+            sourceType: 'csvFile',
+            sourceLabel: 'bank.csv',
+            importBatchId: 'batch-1',
+            provider: 'bank-a',
+        })
+        expect(wrapped.freshnessStatus).toBe('unknown')
+    })
+
+    it('marks restored data with backup provenance and integrity confidence', () => {
+        const wrapped = attachBackupRestoreProvenance(
+            {id: 2, name: 'Main'},
+            {filePath: '/tmp/backup.json', exportedAt: '2026-05-01T00:00:00.000Z', restoredAt: '2026-05-11T00:00:00.000Z', integrityStatus: 'valid'},
+        )
+
+        expect(wrapped.provenance).toMatchObject({
+            origin: 'backupRestore',
+            sourceType: 'backupFile',
+            sourceLabel: '/tmp/backup.json',
+            confidence: 'high',
+        })
+    })
+
+    it('derives market snapshot freshness from provider observation time', () => {
+        const wrapped = attachMarketSnapshotProvenance({
+            provider: 'fixture-provider',
+            symbol: 'AAPL',
+            pricedAt: '2026-05-11T10:00:00.000Z',
+            retrievedAt: '2026-05-11T10:01:00.000Z',
+            staleAfterHours: 2,
+        }, '2026-05-11T11:00:00.000Z')
+
+        expect(wrapped.provenance).toMatchObject({origin: 'marketDataProvider', provider: 'fixture-provider'})
+        expect(wrapped.freshnessStatus).toBe('fresh')
+    })
+
+    it('marks valuations and projections as calculated or provider-backed', () => {
+        const valuation = attachValuationProvenance(
+            {marketValue: 100},
+            {sourceLabel: 'AAPL', snapshotPricedAt: '2026-05-01T00:00:00.000Z', provider: 'fixture-provider', staleAfterHours: 24},
+            '2026-05-11T00:00:00.000Z',
+        )
+        expect(valuation.provenance.origin).toBe('marketDataProvider')
+        expect(valuation.freshnessStatus).toBe('stale')
+
+        const projection = attachProjectionProvenance(
+            {projectedValue: 5000},
+            {goalId: 7, scenarioId: 3, calculatedAt: '2026-05-11T00:00:00.000Z', staleAfter: '30d'},
+            '2026-05-12T00:00:00.000Z',
+        )
+        expect(projection.provenance).toMatchObject({origin: 'calculated', sourceType: 'calculation'})
+        expect(projection.provenance.metadata).toMatchObject({goalId: 7, scenarioId: 3})
+        expect(projection.freshnessStatus).toBe('fresh')
+    })
+})

--- a/src/test/utils/provenance.test.ts
+++ b/src/test/utils/provenance.test.ts
@@ -1,0 +1,113 @@
+import {describe, expect, it} from 'vitest'
+import {
+    calculateDataFreshness,
+    createDataProvenance,
+    provenanceFromBackupRestore,
+    provenanceFromCalculation,
+    provenanceFromImportBatch,
+    provenanceFromMarketData,
+    sanitizeProvenanceMetadata,
+    withFreshness,
+} from '../../utils/provenance'
+
+describe('data provenance helpers', () => {
+    it('calculates fresh, stale, unknown, user provided and unavailable states', () => {
+        expect(calculateDataFreshness({
+            origin: 'marketDataProvider',
+            observedAt: '2026-05-11T10:00:00.000Z',
+            staleAfter: '4h',
+            now: '2026-05-11T12:00:00.000Z',
+        })).toBe('fresh')
+
+        expect(calculateDataFreshness({
+            origin: 'marketDataProvider',
+            observedAt: '2026-05-10T10:00:00.000Z',
+            staleAfter: '4h',
+            now: '2026-05-11T12:00:00.000Z',
+        })).toBe('stale')
+
+        expect(calculateDataFreshness({origin: 'marketDataProvider', observedAt: null, staleAfter: '4h'})).toBe('unknown')
+        expect(calculateDataFreshness({origin: 'manual', observedAt: '2020-01-01T00:00:00.000Z', staleAfter: '1h'})).toBe('userProvided')
+        expect(calculateDataFreshness({unavailable: true})).toBe('unavailable')
+    })
+
+    it('creates generic provenance with inferred source type and sanitized metadata', () => {
+        const provenance = createDataProvenance({
+            origin: 'csvImport',
+            sourceLabel: 'bank.csv',
+            importBatchId: 42,
+            provider: 'bank-a',
+            createdAt: '2026-05-11T10:00:00.000Z',
+            observedAt: '2026-05-11T10:00:00.000Z',
+            staleAfter: '30d',
+            confidence: 'high',
+            metadata: {
+                fileHash: 'abc',
+                apiKey: 'must-not-leak',
+                nested: {secret: true},
+                rowCount: 3,
+            },
+        })
+
+        expect(provenance).toMatchObject({
+            origin: 'csvImport',
+            sourceType: 'csvFile',
+            sourceLabel: 'bank.csv',
+            importBatchId: 42,
+            provider: 'bank-a',
+            confidence: 'high',
+            metadata: {fileHash: 'abc', rowCount: 3},
+        })
+        expect(Object.keys(provenance.metadata)).not.toContain('apiKey')
+        expect(Object.keys(provenance.metadata)).not.toContain('nested')
+    })
+
+    it('builds provenance for imports, restores, market data and calculations', () => {
+        expect(provenanceFromImportBatch({
+            id: 'batch-1',
+            provider: 'bank-a',
+            fileName: 'checking.csv',
+            importedAt: '2026-05-10T10:00:00.000Z',
+            appliedAt: '2026-05-10T10:05:00.000Z',
+        })).toMatchObject({
+            origin: 'csvImport',
+            sourceType: 'csvFile',
+            sourceLabel: 'checking.csv',
+            importBatchId: 'batch-1',
+            provider: 'bank-a',
+        })
+
+        expect(provenanceFromBackupRestore({
+            filePath: '/tmp/backup.json',
+            exportedAt: '2026-05-01T00:00:00.000Z',
+            restoredAt: '2026-05-11T00:00:00.000Z',
+            integrityStatus: 'valid',
+        })).toMatchObject({origin: 'backupRestore', sourceType: 'backupFile', confidence: 'high'})
+
+        const marketData = withFreshness(provenanceFromMarketData({
+            provider: 'fixture-provider',
+            symbol: 'AAPL',
+            pricedAt: '2026-05-11T10:00:00.000Z',
+            staleAfterHours: 24,
+        }), '2026-05-11T12:00:00.000Z')
+        expect(marketData).toMatchObject({origin: 'marketDataProvider', sourceType: 'marketDataProvider', freshnessStatus: 'fresh'})
+
+        const calculated = withFreshness(provenanceFromCalculation({
+            sourceLabel: 'Projection mensuelle',
+            calculatedAt: '2026-05-01T00:00:00.000Z',
+            staleAfter: '7d',
+        }), '2026-05-11T00:00:00.000Z')
+        expect(calculated).toMatchObject({origin: 'calculated', sourceType: 'calculation', freshnessStatus: 'stale'})
+    })
+
+    it('removes secret-like metadata keys', () => {
+        expect(sanitizeProvenanceMetadata({
+            token: 'nope',
+            password: 'nope',
+            authorization: 'nope',
+            provider: 'ok',
+            confidence: 0.8,
+            enabled: true,
+        })).toEqual({provider: 'ok', confidence: 0.8, enabled: true})
+    })
+})

--- a/src/types/provenance.ts
+++ b/src/types/provenance.ts
@@ -1,0 +1,57 @@
+export type DataOrigin =
+    | 'manual'
+    | 'csvImport'
+    | 'backupRestore'
+    | 'generatedFromRecurring'
+    | 'calculated'
+    | 'marketDataProvider'
+    | 'connectorReadOnly'
+    | 'migration'
+
+export type DataFreshnessStatus =
+    | 'fresh'
+    | 'stale'
+    | 'unknown'
+    | 'userProvided'
+    | 'unavailable'
+
+export type ProvenanceSourceType =
+    | 'user'
+    | 'csvFile'
+    | 'backupFile'
+    | 'recurringTemplate'
+    | 'calculation'
+    | 'marketDataProvider'
+    | 'connector'
+    | 'migration'
+    | 'system'
+
+export type DataConfidence = 'low' | 'medium' | 'high' | number
+
+export interface DataProvenance {
+    origin: DataOrigin
+    sourceType: ProvenanceSourceType
+    sourceLabel: string | null
+    importBatchId: string | number | null
+    provider: string | null
+    createdAt: string
+    updatedAt: string
+    observedAt: string | null
+    staleAfter: string | number | null
+    confidence: DataConfidence | null
+    metadata: Record<string, string | number | boolean | null>
+}
+
+export interface DataFreshnessInput {
+    origin?: DataOrigin | null
+    observedAt?: string | Date | null
+    staleAfter?: string | number | null
+    unavailable?: boolean | null
+    now?: string | Date | null
+}
+
+export interface DataWithProvenance<T> {
+    data: T
+    provenance: DataProvenance
+    freshnessStatus: DataFreshnessStatus
+}

--- a/src/utils/domainProvenance.ts
+++ b/src/utils/domainProvenance.ts
@@ -1,0 +1,139 @@
+import type {DataFreshnessStatus, DataProvenance} from '../types/provenance'
+import {
+    calculateDataFreshness,
+    provenanceFromBackupRestore,
+    provenanceFromCalculation,
+    provenanceFromImportBatch,
+    provenanceFromMarketData,
+    withFreshness,
+} from './provenance'
+
+export interface ProvenanceEnvelope<T> {
+    value: T
+    provenance: DataProvenance
+    freshnessStatus: DataFreshnessStatus
+}
+
+export function attachImportedTransactionProvenance<T extends Record<string, unknown>>(
+    transaction: T,
+    batch: {
+        id?: string | number | null
+        provider?: string | null
+        fileName?: string | null
+        importedAt?: string | Date | null
+        appliedAt?: string | Date | null
+        createdAt?: string | Date | null
+        updatedAt?: string | Date | null
+    },
+): ProvenanceEnvelope<T> {
+    const provenance = provenanceFromImportBatch(batch)
+    return {
+        value: transaction,
+        provenance,
+        freshnessStatus: calculateDataFreshness({origin: provenance.origin, observedAt: provenance.observedAt, staleAfter: provenance.staleAfter}),
+    }
+}
+
+export function attachBackupRestoreProvenance<T extends Record<string, unknown>>(
+    value: T,
+    restore: {
+        filePath?: string | null
+        exportedAt?: string | Date | null
+        restoredAt?: string | Date | null
+        integrityStatus?: string | null
+    },
+): ProvenanceEnvelope<T> {
+    const provenance = provenanceFromBackupRestore(restore)
+    return {
+        value,
+        provenance,
+        freshnessStatus: calculateDataFreshness({origin: provenance.origin, observedAt: provenance.observedAt, staleAfter: provenance.staleAfter}),
+    }
+}
+
+export function attachMarketSnapshotProvenance<T extends {
+    provider?: string | null
+    symbol?: string | null
+    exchange?: string | null
+    pricedAt?: string | Date | null
+    retrievedAt?: string | Date | null
+    staleAfterHours?: number | null
+}>(snapshot: T, now?: string | Date): ProvenanceEnvelope<T> {
+    const provenance = provenanceFromMarketData({
+        provider: snapshot.provider,
+        symbol: snapshot.symbol,
+        exchange: snapshot.exchange,
+        pricedAt: snapshot.pricedAt,
+        retrievedAt: snapshot.retrievedAt,
+        staleAfterHours: snapshot.staleAfterHours,
+    })
+    return {
+        value: snapshot,
+        provenance,
+        freshnessStatus: withFreshness(provenance, now || null).freshnessStatus,
+    }
+}
+
+export function attachValuationProvenance<T extends Record<string, unknown>>(
+    valuation: T,
+    input: {
+        sourceLabel?: string | null
+        calculatedAt?: string | Date | null
+        snapshotPricedAt?: string | Date | null
+        provider?: string | null
+        staleAfterHours?: number | null
+        confidence?: DataProvenance['confidence']
+    } = {},
+    now?: string | Date,
+): ProvenanceEnvelope<T> {
+    const provenance = input.provider || input.snapshotPricedAt
+        ? provenanceFromMarketData({
+            provider: input.provider,
+            symbol: input.sourceLabel,
+            pricedAt: input.snapshotPricedAt || input.calculatedAt || null,
+            retrievedAt: input.calculatedAt || null,
+            staleAfterHours: input.staleAfterHours ?? 24,
+            confidence: input.confidence ?? 'medium',
+        })
+        : provenanceFromCalculation({
+            sourceLabel: input.sourceLabel || 'Valuation',
+            calculatedAt: input.calculatedAt || null,
+            staleAfter: input.staleAfterHours ? `${input.staleAfterHours}h` : null,
+            confidence: input.confidence ?? 'medium',
+        })
+
+    return {
+        value: valuation,
+        provenance,
+        freshnessStatus: withFreshness(provenance, now || null).freshnessStatus,
+    }
+}
+
+export function attachProjectionProvenance<T extends Record<string, unknown>>(
+    projection: T,
+    input: {
+        scenarioId?: string | number | null
+        goalId?: string | number | null
+        calculatedAt?: string | Date | null
+        staleAfter?: string | number | null
+        confidence?: DataProvenance['confidence']
+    } = {},
+    now?: string | Date,
+): ProvenanceEnvelope<T> {
+    const provenance = provenanceFromCalculation({
+        sourceLabel: 'Goal projection',
+        calculatedAt: input.calculatedAt || null,
+        staleAfter: input.staleAfter ?? '30d',
+        confidence: input.confidence ?? 'medium',
+        metadata: {
+            scenarioId: input.scenarioId ?? null,
+            goalId: input.goalId ?? null,
+        },
+    })
+
+    return {
+        value: projection,
+        provenance,
+        freshnessStatus: withFreshness(provenance, now || null).freshnessStatus,
+    }
+}

--- a/src/utils/provenance.ts
+++ b/src/utils/provenance.ts
@@ -1,0 +1,215 @@
+import type {
+    DataFreshnessInput,
+    DataFreshnessStatus,
+    DataOrigin,
+    DataProvenance,
+    ProvenanceSourceType,
+} from '../types/provenance'
+
+export const DATA_ORIGINS: readonly DataOrigin[] = [
+    'manual',
+    'csvImport',
+    'backupRestore',
+    'generatedFromRecurring',
+    'calculated',
+    'marketDataProvider',
+    'connectorReadOnly',
+    'migration',
+]
+
+export const DATA_FRESHNESS_STATUSES: readonly DataFreshnessStatus[] = [
+    'fresh',
+    'stale',
+    'unknown',
+    'userProvided',
+    'unavailable',
+]
+
+const ORIGIN_TO_SOURCE_TYPE: Record<DataOrigin, ProvenanceSourceType> = {
+    manual: 'user',
+    csvImport: 'csvFile',
+    backupRestore: 'backupFile',
+    generatedFromRecurring: 'recurringTemplate',
+    calculated: 'calculation',
+    marketDataProvider: 'marketDataProvider',
+    connectorReadOnly: 'connector',
+    migration: 'migration',
+}
+
+const SECRET_KEYS = /secret|password|token|api[-_]?key|authorization|credential/i
+
+function toDate(value: string | Date | null | undefined): Date | null {
+    if (!value) return null
+    const date = value instanceof Date ? value : new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+}
+
+function toIso(value: string | Date | null | undefined): string | null {
+    return toDate(value)?.toISOString() || null
+}
+
+function parseStaleAfterMs(value: string | number | null | undefined): number | null {
+    if (value == null || value === '') return null
+    if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : null
+    const match = value.trim().match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/i)
+    if (!match) return null
+    const amount = Number(match[1])
+    if (!Number.isFinite(amount) || amount <= 0) return null
+    const unit = match[2].toLowerCase()
+    if (unit === 'ms') return amount
+    if (unit === 's') return amount * 1000
+    if (unit === 'm') return amount * 60 * 1000
+    if (unit === 'h') return amount * 60 * 60 * 1000
+    return amount * 24 * 60 * 60 * 1000
+}
+
+export function sanitizeProvenanceMetadata(metadata: Record<string, unknown> = {}): DataProvenance['metadata'] {
+    const sanitized: DataProvenance['metadata'] = {}
+    for (const [key, value] of Object.entries(metadata)) {
+        if (SECRET_KEYS.test(key)) continue
+        if (value == null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+            sanitized[key] = value as string | number | boolean | null
+        }
+    }
+    return sanitized
+}
+
+export function inferSourceType(origin: DataOrigin): ProvenanceSourceType {
+    return ORIGIN_TO_SOURCE_TYPE[origin]
+}
+
+export function calculateDataFreshness(input: DataFreshnessInput = {}): DataFreshnessStatus {
+    if (input.unavailable) return 'unavailable'
+    if (input.origin === 'manual') return 'userProvided'
+
+    const observedAt = toDate(input.observedAt)
+    if (!observedAt) return 'unknown'
+
+    const staleAfterMs = parseStaleAfterMs(input.staleAfter)
+    if (!staleAfterMs) return 'unknown'
+
+    const now = toDate(input.now) || new Date()
+    return now.getTime() - observedAt.getTime() <= staleAfterMs ? 'fresh' : 'stale'
+}
+
+export function createDataProvenance(input: Partial<DataProvenance> & {
+    origin: DataOrigin
+    createdAt?: string | Date | null
+    updatedAt?: string | Date | null
+    observedAt?: string | Date | null
+    metadata?: Record<string, unknown>
+}): DataProvenance {
+    const now = new Date().toISOString()
+    const createdAt = toIso(input.createdAt) || now
+    const updatedAt = toIso(input.updatedAt) || createdAt
+
+    return {
+        origin: input.origin,
+        sourceType: input.sourceType || inferSourceType(input.origin),
+        sourceLabel: input.sourceLabel ?? null,
+        importBatchId: input.importBatchId ?? null,
+        provider: input.provider ?? null,
+        createdAt,
+        updatedAt,
+        observedAt: toIso(input.observedAt) || null,
+        staleAfter: input.staleAfter ?? null,
+        confidence: input.confidence ?? null,
+        metadata: sanitizeProvenanceMetadata(input.metadata || input.metadata === undefined ? input.metadata || {} : {}),
+    }
+}
+
+export function withFreshness(provenance: DataProvenance, now: string | Date | null = null): DataProvenance & {freshnessStatus: DataFreshnessStatus} {
+    return {
+        ...provenance,
+        freshnessStatus: calculateDataFreshness({
+            origin: provenance.origin,
+            observedAt: provenance.observedAt,
+            staleAfter: provenance.staleAfter,
+            now,
+        }),
+    }
+}
+
+export function provenanceFromImportBatch(batch: {
+    id?: string | number | null
+    provider?: string | null
+    fileName?: string | null
+    importedAt?: string | Date | null
+    appliedAt?: string | Date | null
+    createdAt?: string | Date | null
+    updatedAt?: string | Date | null
+}): DataProvenance {
+    return createDataProvenance({
+        origin: 'csvImport',
+        sourceType: 'csvFile',
+        sourceLabel: batch.fileName || batch.provider || 'Import CSV',
+        importBatchId: batch.id ?? null,
+        provider: batch.provider ?? null,
+        createdAt: batch.createdAt || batch.importedAt || null,
+        updatedAt: batch.updatedAt || batch.appliedAt || batch.importedAt || null,
+        observedAt: batch.appliedAt || batch.importedAt || null,
+        confidence: 'medium',
+        metadata: {fileName: batch.fileName ?? null},
+    })
+}
+
+export function provenanceFromBackupRestore(input: {
+    filePath?: string | null
+    exportedAt?: string | Date | null
+    restoredAt?: string | Date | null
+    integrityStatus?: string | null
+} = {}): DataProvenance {
+    return createDataProvenance({
+        origin: 'backupRestore',
+        sourceType: 'backupFile',
+        sourceLabel: input.filePath || 'Backup restore',
+        createdAt: input.restoredAt || null,
+        updatedAt: input.restoredAt || null,
+        observedAt: input.exportedAt || null,
+        confidence: input.integrityStatus === 'valid' ? 'high' : 'medium',
+        metadata: {integrityStatus: input.integrityStatus ?? null},
+    })
+}
+
+export function provenanceFromMarketData(input: {
+    provider?: string | null
+    symbol?: string | null
+    exchange?: string | null
+    pricedAt?: string | Date | null
+    retrievedAt?: string | Date | null
+    staleAfterHours?: number | null
+    confidence?: DataProvenance['confidence']
+}): DataProvenance {
+    return createDataProvenance({
+        origin: 'marketDataProvider',
+        sourceType: 'marketDataProvider',
+        sourceLabel: input.symbol || input.provider || 'Market data',
+        provider: input.provider ?? null,
+        createdAt: input.retrievedAt || null,
+        updatedAt: input.retrievedAt || null,
+        observedAt: input.pricedAt || input.retrievedAt || null,
+        staleAfter: input.staleAfterHours ? `${input.staleAfterHours}h` : null,
+        confidence: input.confidence ?? 'medium',
+        metadata: {symbol: input.symbol ?? null, exchange: input.exchange ?? null},
+    })
+}
+
+export function provenanceFromCalculation(input: {
+    sourceLabel?: string | null
+    calculatedAt?: string | Date | null
+    staleAfter?: string | number | null
+    confidence?: DataProvenance['confidence']
+    metadata?: Record<string, unknown>
+} = {}): DataProvenance {
+    return createDataProvenance({
+        origin: 'calculated',
+        sourceType: 'calculation',
+        sourceLabel: input.sourceLabel || 'Calculated value',
+        createdAt: input.calculatedAt || null,
+        updatedAt: input.calculatedAt || null,
+        observedAt: input.calculatedAt || null,
+        staleAfter: input.staleAfter ?? null,
+        confidence: input.confidence ?? 'medium',
+        metadata: input.metadata || {},
+    })
+}


### PR DESCRIPTION
Closes #96

## Summary
- add shared TypeScript types for data origin, freshness status, provenance source type and provenance metadata
- add reusable freshness/provenance helpers for manual data, CSV imports, backup restores, recurring/generated/calculated data, market providers, connectors and migrations
- add domain adapters for imported transactions, restored entities, market snapshots, valuations and goal projections without introducing DB duplication or secrets
- sanitize provenance metadata to avoid token/password/API key leakage
- add Vitest coverage for fresh/stale/unknown/user-provided/unavailable states and domain provenance mapping

## Notes
- This PR intentionally avoids a Prisma migration. The issue asks for the common model; existing tables already carry domain-specific timestamps/provider/import IDs that can feed the generic provenance object.
- UI display is left out of scope as requested.

## Tests
- Not run locally: repository dependency install/build was not available in this environment.