### PR TITLE
provenance-ui: display freshness and origin indicators

### DIFF
--- a/src/components/ImportHistorySection.vue
+++ b/src/components/ImportHistorySection.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import {computed, onMounted, ref} from 'vue'
+import FreshnessBadge from './provenance/FreshnessBadge.vue'
+import ProvenanceBadge from './provenance/ProvenanceBadge.vue'
+import DataOriginTooltip from './provenance/DataOriginTooltip.vue'
 import type {ImportEntityId} from '../types/imports'
+import {provenanceFromImportBatch, withFreshness} from '../utils/provenance'
 
 interface ImportHistoryItem {
   id: ImportEntityId
@@ -24,6 +28,8 @@ interface ImportHistoryItem {
   previewedAt?: string | null
   appliedAt?: string | null
   cancelledAt?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
 }
 
 interface ImportAuditDetail extends ImportHistoryItem {
@@ -94,6 +100,22 @@ function statusClass(status: string) {
   if (status === 'partiallyApplied' || status === 'previewed') return 'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-950/30 dark:text-amber-200 dark:ring-amber-900'
   if (status === 'cancelled') return 'bg-slate-100 text-slate-600 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700'
   return 'bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-950/30 dark:text-sky-200 dark:ring-sky-900'
+}
+
+function importProvenance(item: ImportHistoryItem) {
+  return provenanceFromImportBatch({
+    id: item.id,
+    provider: item.provider || item.source || null,
+    fileName: item.fileName || null,
+    importedAt: item.importedAt || null,
+    appliedAt: item.appliedAt || null,
+    createdAt: item.createdAt || item.importedAt || null,
+    updatedAt: item.updatedAt || item.appliedAt || item.importedAt || null,
+  })
+}
+
+function importFreshness(item: ImportHistoryItem) {
+  return withFreshness(importProvenance(item)).freshnessStatus
 }
 
 async function loadHistory() {
@@ -203,7 +225,13 @@ onMounted(loadHistory)
             <tr v-for="item in history" :key="String(item.id)" class="cursor-pointer align-top hover:bg-slate-50 dark:hover:bg-slate-950/40" @click="openDetail(item.id)">
               <td class="px-3 py-3 text-xs text-slate-500">{{ formatDate(item.importedAt) }}</td>
               <td class="px-3 py-3"><p class="font-semibold">{{ item.fileName || '—' }}</p><p class="text-xs text-slate-400">{{ item.importType }}</p></td>
-              <td class="px-3 py-3 text-xs">{{ item.source || item.provider || 'manual' }}</td>
+              <td class="px-3 py-3 text-xs">
+                <div class="flex flex-wrap items-center gap-1.5">
+                  <ProvenanceBadge :provenance="importProvenance(item)" compact />
+                  <DataOriginTooltip :provenance="importProvenance(item)" :freshness-status="importFreshness(item)" />
+                </div>
+                <p class="mt-1 text-slate-500">{{ item.source || item.provider || 'manual' }}</p>
+              </td>
               <td class="px-3 py-3"><span class="rounded-full px-2.5 py-1 text-xs font-bold ring-1 ring-inset" :class="statusClass(item.status)">{{ item.status }}</span></td>
               <td class="px-3 py-3 text-xs">{{ item.rowCount }} lignes<br />{{ item.appliedRowCount || 0 }} appliquées</td>
               <td class="px-3 py-3 text-xs">{{ item.errorCount }} erreurs<br />{{ item.duplicateCount }} doublons</td>
@@ -220,6 +248,11 @@ onMounted(loadHistory)
           <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <h3 class="text-lg font-bold text-slate-950 dark:text-white">{{ selected.fileName || selected.id }}</h3>
+              <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                <ProvenanceBadge :provenance="importProvenance(selected)" />
+                <FreshnessBadge :status="importFreshness(selected)" :provenance="importProvenance(selected)" />
+                <DataOriginTooltip :provenance="importProvenance(selected)" :freshness-status="importFreshness(selected)" />
+              </div>
               <p class="mt-1 text-xs text-slate-500">{{ selected.source }} · {{ selected.importType }} · {{ formatDate(selected.importedAt) }}</p>
             </div>
             <div class="flex flex-wrap gap-2">

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import {useI18n} from 'vue-i18n'
+import FreshnessBadge from './provenance/FreshnessBadge.vue'
+import ProvenanceBadge from './provenance/ProvenanceBadge.vue'
 import type {SupportedLocale} from '../i18n'
 
 const props = defineProps<{
@@ -58,6 +60,28 @@ const {t} = useI18n()
             <option value="dark">{{ t('settings.themeDark') }}</option>
           </select>
         </div>
+
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/60">
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            Confiance des données
+          </p>
+          <h4 class="mt-1 text-sm font-bold text-slate-900 dark:text-white">
+            Provenance et fraîcheur
+          </h4>
+          <p class="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+            Les badges indiquent si une donnée vient d’une saisie manuelle, d’un import, d’un restore, d’un calcul ou d’un provider externe. Les tooltips affichent la source, la date observée et la raison d’un statut obsolète sans exposer de secrets.
+          </p>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <ProvenanceBadge origin="manual" />
+            <ProvenanceBadge origin="csvImport" />
+            <ProvenanceBadge origin="backupRestore" />
+            <ProvenanceBadge origin="calculated" />
+            <ProvenanceBadge origin="marketDataProvider" />
+            <FreshnessBadge status="fresh" />
+            <FreshnessBadge status="stale" />
+            <FreshnessBadge status="unknown" />
+          </div>
+        </section>
       </div>
 
       <div class="form-actions mt-6">

--- a/src/components/TransactionsSection.vue
+++ b/src/components/TransactionsSection.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import {computed} from 'vue'
 import {useI18n} from 'vue-i18n'
+import FreshnessBadge from './provenance/FreshnessBadge.vue'
+import ProvenanceBadge from './provenance/ProvenanceBadge.vue'
+import DataOriginTooltip from './provenance/DataOriginTooltip.vue'
 import type {Account, Category, Transaction, TransactionKind} from '../types/budget'
+import type {DataFreshnessStatus, DataProvenance} from '../types/provenance'
 import {
   amountClass,
   categoryDotStyle,
@@ -17,10 +21,15 @@ import {
   transferRoute,
 } from '../utils/transferDisplay'
 
+type TransactionWithProvenance = Transaction & {
+  provenance?: DataProvenance | null
+  freshnessStatus?: DataFreshnessStatus | null
+}
+
 const props = defineProps<{
   accounts: Account[]
   categories: Category[]
-  filteredTransactions: Transaction[]
+  filteredTransactions: TransactionWithProvenance[]
   search: string
   kindFilter: 'ALL' | TransactionKind
   accountFilter: string
@@ -44,6 +53,10 @@ const displayTransactions = computed(() => props.filteredTransactions)
 function transferCategoryLabel(transaction: Transaction) {
   if (transaction.kind === 'TRANSFER') return t('transfer.internal')
   return transaction.category?.name || t('common.none')
+}
+
+function hasProvenance(transaction: TransactionWithProvenance) {
+  return Boolean(transaction.provenance || transaction.freshnessStatus)
 }
 </script>
 
@@ -175,6 +188,12 @@ function transferCategoryLabel(transaction: Transaction) {
                 <p class="font-semibold text-slate-800 dark:text-slate-100">
                   {{ transaction.label }}
                 </p>
+
+                <div v-if="hasProvenance(transaction)" class="flex flex-wrap items-center gap-1.5">
+                  <ProvenanceBadge v-if="transaction.provenance" :provenance="transaction.provenance" compact />
+                  <FreshnessBadge v-if="transaction.freshnessStatus" :status="transaction.freshnessStatus" :provenance="transaction.provenance" compact />
+                  <DataOriginTooltip :provenance="transaction.provenance" :freshness-status="transaction.freshnessStatus" />
+                </div>
 
                 <p
                     v-if="transaction.kind === 'TRANSFER' && transferRoute(transaction)"

--- a/src/components/provenance/DataOriginTooltip.vue
+++ b/src/components/provenance/DataOriginTooltip.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type {DataFreshnessStatus, DataProvenance} from '../../types/provenance'
+import {FRESHNESS_LABELS, ORIGIN_LABELS, formatProvenanceDate, freshnessReason} from './provenanceDisplay'
+
+const props = defineProps<{
+  provenance?: DataProvenance | null
+  freshnessStatus?: DataFreshnessStatus | null
+}>()
+</script>
+
+<template>
+  <details class="group relative inline-block text-left">
+    <summary
+        class="inline-flex cursor-help list-none items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-500 transition hover:border-slate-300 hover:text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700"
+        aria-label="Afficher la provenance"
+    >
+      i
+    </summary>
+    <div
+        class="absolute right-0 z-50 mt-2 w-72 rounded-2xl border border-slate-200 bg-white p-3 text-xs leading-5 text-slate-600 shadow-xl dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300"
+    >
+      <p class="font-bold text-slate-900 dark:text-white">Provenance</p>
+      <dl class="mt-2 space-y-1">
+        <div class="flex justify-between gap-3">
+          <dt class="text-slate-400">Origine</dt>
+          <dd class="text-right font-medium">{{ props.provenance ? ORIGIN_LABELS[props.provenance.origin] : 'Non disponible' }}</dd>
+        </div>
+        <div class="flex justify-between gap-3">
+          <dt class="text-slate-400">Source</dt>
+          <dd class="text-right font-medium">{{ props.provenance?.sourceLabel || props.provenance?.provider || '—' }}</dd>
+        </div>
+        <div v-if="props.provenance?.importBatchId != null" class="flex justify-between gap-3">
+          <dt class="text-slate-400">Batch</dt>
+          <dd class="text-right font-medium">{{ props.provenance.importBatchId }}</dd>
+        </div>
+        <div class="flex justify-between gap-3">
+          <dt class="text-slate-400">Observé</dt>
+          <dd class="text-right font-medium">{{ formatProvenanceDate(props.provenance?.observedAt) }}</dd>
+        </div>
+        <div class="flex justify-between gap-3">
+          <dt class="text-slate-400">Mis à jour</dt>
+          <dd class="text-right font-medium">{{ formatProvenanceDate(props.provenance?.updatedAt) }}</dd>
+        </div>
+        <div v-if="props.freshnessStatus" class="flex justify-between gap-3">
+          <dt class="text-slate-400">Fraîcheur</dt>
+          <dd class="text-right font-medium">{{ FRESHNESS_LABELS[props.freshnessStatus] }}</dd>
+        </div>
+      </dl>
+      <p v-if="props.freshnessStatus" class="mt-2 rounded-xl bg-slate-50 p-2 text-[11px] text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+        {{ freshnessReason(props.freshnessStatus, props.provenance) }}
+      </p>
+    </div>
+  </details>
+</template>
+
+<style scoped>
+summary::-webkit-details-marker {
+  display: none;
+}
+</style>

--- a/src/components/provenance/FreshnessBadge.vue
+++ b/src/components/provenance/FreshnessBadge.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type {DataFreshnessStatus, DataProvenance} from '../../types/provenance'
+import {FRESHNESS_LABELS, freshnessReason, freshnessTone} from './provenanceDisplay'
+
+const props = withDefaults(defineProps<{
+  status: DataFreshnessStatus
+  provenance?: DataProvenance | null
+  compact?: boolean
+}>(), {
+  compact: false,
+  provenance: null,
+})
+</script>
+
+<template>
+  <span
+      class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold leading-5 ring-1 ring-inset ring-transparent"
+      :class="freshnessTone(props.status)"
+      :title="freshnessReason(props.status, props.provenance)"
+  >
+    <span class="mr-1 h-1.5 w-1.5 rounded-full bg-current opacity-70" />
+    {{ props.compact ? FRESHNESS_LABELS[props.status].slice(0, 3) : FRESHNESS_LABELS[props.status] }}
+  </span>
+</template>

--- a/src/components/provenance/ProvenanceBadge.vue
+++ b/src/components/provenance/ProvenanceBadge.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type {DataOrigin, DataProvenance} from '../../types/provenance'
+import {ORIGIN_LABELS, originTone, provenanceTooltip} from './provenanceDisplay'
+
+const props = withDefaults(defineProps<{
+  provenance?: DataProvenance | null
+  origin?: DataOrigin | null
+  compact?: boolean
+}>(), {
+  provenance: null,
+  origin: null,
+  compact: false,
+})
+
+function resolvedOrigin() {
+  return props.provenance?.origin || props.origin || 'manual'
+}
+</script>
+
+<template>
+  <span
+      class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold leading-5 ring-1 ring-inset ring-transparent"
+      :class="originTone(resolvedOrigin())"
+      :title="provenanceTooltip(props.provenance)"
+  >
+    {{ props.compact ? ORIGIN_LABELS[resolvedOrigin()].slice(0, 4) : ORIGIN_LABELS[resolvedOrigin()] }}
+  </span>
+</template>

--- a/src/components/provenance/provenanceDisplay.ts
+++ b/src/components/provenance/provenanceDisplay.ts
@@ -1,0 +1,70 @@
+import type {DataFreshnessStatus, DataOrigin, DataProvenance} from '../../types/provenance'
+
+export const ORIGIN_LABELS: Record<DataOrigin, string> = {
+    manual: 'Saisie manuelle',
+    csvImport: 'Importé',
+    backupRestore: 'Restauré',
+    generatedFromRecurring: 'Récurrence',
+    calculated: 'Calculé',
+    marketDataProvider: 'Provider externe',
+    connectorReadOnly: 'Connecteur',
+    migration: 'Migration',
+}
+
+export const FRESHNESS_LABELS: Record<DataFreshnessStatus, string> = {
+    fresh: 'Frais',
+    stale: 'Obsolète',
+    unknown: 'Inconnu',
+    userProvided: 'Utilisateur',
+    unavailable: 'Indisponible',
+}
+
+export function freshnessTone(status: DataFreshnessStatus) {
+    if (status === 'fresh') return 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200'
+    if (status === 'stale') return 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200'
+    if (status === 'unavailable') return 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200'
+    if (status === 'userProvided') return 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-200'
+    return 'border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300'
+}
+
+export function originTone(origin: DataOrigin) {
+    if (origin === 'csvImport') return 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-200'
+    if (origin === 'backupRestore') return 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900/60 dark:bg-violet-950/40 dark:text-violet-200'
+    if (origin === 'calculated' || origin === 'generatedFromRecurring') return 'border-fuchsia-200 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-900/60 dark:bg-fuchsia-950/40 dark:text-fuchsia-200'
+    if (origin === 'marketDataProvider' || origin === 'connectorReadOnly') return 'border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-900/60 dark:bg-cyan-950/40 dark:text-cyan-200'
+    if (origin === 'migration') return 'border-slate-300 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'
+    return 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-200'
+}
+
+export function formatProvenanceDate(value: string | null | undefined) {
+    if (!value) return '—'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    return new Intl.DateTimeFormat('fr-CA', {dateStyle: 'medium', timeStyle: 'short'}).format(date)
+}
+
+export function freshnessReason(status: DataFreshnessStatus, provenance?: DataProvenance | null) {
+    if (status === 'stale') {
+        return `Donnée considérée obsolète${provenance?.staleAfter ? ` après ${provenance.staleAfter}` : ''}.`
+    }
+    if (status === 'fresh') return 'Donnée encore dans sa fenêtre de fraîcheur.'
+    if (status === 'userProvided') return 'Donnée fournie ou confirmée manuellement par l’utilisateur.'
+    if (status === 'unavailable') return 'Aucune donnée exploitable n’est disponible.'
+    return 'Fraîcheur impossible à déterminer avec les métadonnées actuelles.'
+}
+
+export function provenanceTooltip(provenance: DataProvenance | null | undefined, freshnessStatus?: DataFreshnessStatus | null) {
+    if (!provenance) return freshnessStatus ? freshnessReason(freshnessStatus) : 'Aucune provenance disponible.'
+    const lines = [
+        `Origine: ${ORIGIN_LABELS[provenance.origin] || provenance.origin}`,
+        `Source: ${provenance.sourceLabel || provenance.provider || provenance.sourceType}`,
+        provenance.provider ? `Provider: ${provenance.provider}` : null,
+        provenance.importBatchId != null ? `Batch import: ${provenance.importBatchId}` : null,
+        `Observé le: ${formatProvenanceDate(provenance.observedAt)}`,
+        `Mis à jour le: ${formatProvenanceDate(provenance.updatedAt)}`,
+        freshnessStatus ? `Statut: ${FRESHNESS_LABELS[freshnessStatus] || freshnessStatus}` : null,
+        freshnessStatus ? freshnessReason(freshnessStatus, provenance) : null,
+    ].filter(Boolean)
+
+    return lines.join('\n')
+}

--- a/src/test/components/provenanceBadges.test.ts
+++ b/src/test/components/provenanceBadges.test.ts
@@ -1,0 +1,58 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import FreshnessBadge from '../../components/provenance/FreshnessBadge.vue'
+import ProvenanceBadge from '../../components/provenance/ProvenanceBadge.vue'
+import DataOriginTooltip from '../../components/provenance/DataOriginTooltip.vue'
+import {provenanceTooltip} from '../../components/provenance/provenanceDisplay'
+import type {DataProvenance} from '../../types/provenance'
+
+const provenance: DataProvenance = {
+    origin: 'csvImport',
+    sourceType: 'csvFile',
+    sourceLabel: 'checking.csv',
+    importBatchId: 'batch-42',
+    provider: 'bank-a',
+    createdAt: '2026-05-11T10:00:00.000Z',
+    updatedAt: '2026-05-11T10:05:00.000Z',
+    observedAt: '2026-05-11T10:00:00.000Z',
+    staleAfter: '30d',
+    confidence: 'high',
+    metadata: {fileName: 'checking.csv'},
+}
+
+describe('provenance UI badges', () => {
+    it('renders a compact provenance badge with a safe tooltip', () => {
+        const wrapper = mount(ProvenanceBadge, {props: {provenance, compact: true}})
+
+        expect(wrapper.text()).toContain('Impo')
+        expect(wrapper.attributes('title')).toContain('checking.csv')
+        expect(wrapper.attributes('title')).not.toMatch(/token|password|apiKey/i)
+    })
+
+    it('renders freshness states with readable labels and stale reason', () => {
+        const wrapper = mount(FreshnessBadge, {props: {status: 'stale', provenance}})
+
+        expect(wrapper.text()).toContain('Obsolète')
+        expect(wrapper.attributes('title')).toContain('Donnée considérée obsolète')
+        expect(wrapper.attributes('title')).toContain('30d')
+    })
+
+    it('renders detailed origin tooltip content without exposing metadata secrets', () => {
+        const wrapper = mount(DataOriginTooltip, {props: {provenance, freshnessStatus: 'fresh'}})
+
+        expect(wrapper.text()).toContain('Provenance')
+        expect(wrapper.text()).toContain('Importé')
+        expect(wrapper.text()).toContain('checking.csv')
+        expect(wrapper.text()).toContain('Fraîcheur')
+        expect(wrapper.text()).not.toMatch(/token|password|apiKey/i)
+    })
+
+    it('builds plain tooltip text for title attributes', () => {
+        const text = provenanceTooltip(provenance, 'stale')
+
+        expect(text).toContain('Origine: Importé')
+        expect(text).toContain('Batch import: batch-42')
+        expect(text).toContain('Statut: Obsolète')
+        expect(text).not.toMatch(/secret|password|token|api/i)
+    })
+})


### PR DESCRIPTION
Closes #97

## Summary
- add reusable provenance UI components: `FreshnessBadge`, `ProvenanceBadge`, and `DataOriginTooltip`
- add display helpers for labels, tones, dates and safe tooltip text
- show provenance/freshness indicators in transactions when data exposes provenance metadata
- show import provenance indicators in import history list and detail views
- add a compact provenance/freshness legend in settings so users understand the badges
- add component tests covering labels, stale reason text and tooltip safety

## Notes
- The UI remains intentionally discreet: badges only appear where provenance/freshness metadata exists or where the import history can derive it reliably.
- Market data/projection rows can reuse the new components directly once those DTOs surface the provenance envelope in their respective views.
- Tooltips only render explicit provenance fields and sanitized metadata is not displayed.

## Tests
- Not run locally: repository dependency install/build was not available in this environment.