### PR TITLE
recovery: add local snapshots for critical actions

### DIFF
--- a/electron/ipc/registerDbHandlers.js
+++ b/electron/ipc/registerDbHandlers.js
@@ -1,6 +1,8 @@
-const {ipcMain} = require('electron')
+const {app, ipcMain} = require('electron')
 const {getPrisma} = require('../db')
 const {createAuditLogService} = require('../audit/auditLogService')
+const {createRecoverySnapshotService} = require('../recovery/recoverySnapshotService')
+const {createDatabaseRecoverySnapshot} = require('../recovery/databaseRecoveryBackup')
 const {
     buildAccountPayload,
     buildCategoryPayload,
@@ -11,8 +13,15 @@ const {
     updateTransaction,
 } = require('./transactionHandlers')
 
-function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma()})} = {}) {
+function registerDbHandlers({
+    auditLog = createAuditLogService({prisma: getPrisma()}),
+    recoverySnapshots = createRecoverySnapshotService({app, auditLog}),
+} = {}) {
     const prisma = getPrisma()
+
+    async function snapshotBefore(operationType, reason, source) {
+        return createDatabaseRecoverySnapshot({prisma, recoverySnapshots, operationType, reason, source})
+    }
 
     ipcMain.handle('db:account:list', async () => {
         return prisma.account.findMany({
@@ -35,6 +44,7 @@ function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma
 
     ipcMain.handle('db:account:delete', async (_event, id) => {
         const accountId = requireId(id, 'Le compte')
+        const recovery = await snapshotBefore('delete-account', `Suppression du compte ${accountId}`, 'db:account:delete')
         const deleted = await prisma.account.delete({
             where: {id: accountId},
         })
@@ -44,7 +54,7 @@ function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma
             entityId: accountId,
             summary: `Compte supprimé: ${deleted.name}`,
             source: 'db:account:delete',
-            metadata: {type: deleted.type, currency: deleted.currency},
+            metadata: {type: deleted.type, currency: deleted.currency, recoverySnapshotId: recovery?.id, recoverySnapshotPath: recovery?.filePath},
         })
         return deleted
     })
@@ -104,6 +114,7 @@ function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma
 
     ipcMain.handle('db:transaction:delete', async (_event, id) => {
         const transactionId = requireId(id, 'La transaction')
+        const recovery = await snapshotBefore('delete-transaction', `Suppression de la transaction ${transactionId}`, 'db:transaction:delete')
         const deleted = await deleteTransaction(prisma, transactionId)
         await auditLog.logCriticalDelete({
             domain: 'transaction',
@@ -111,7 +122,7 @@ function registerDbHandlers({auditLog = createAuditLogService({prisma: getPrisma
             entityId: transactionId,
             summary: `Transaction supprimée: ${deleted.label}`,
             source: 'db:transaction:delete',
-            metadata: {kind: deleted.kind, date: deleted.date, accountId: deleted.accountId, categoryId: deleted.categoryId},
+            metadata: {kind: deleted.kind, date: deleted.date, accountId: deleted.accountId, categoryId: deleted.categoryId, recoverySnapshotId: recovery?.id, recoverySnapshotPath: recovery?.filePath},
         })
         return deleted
     })

--- a/electron/ipc/registerRecoverySnapshotHandlers.js
+++ b/electron/ipc/registerRecoverySnapshotHandlers.js
@@ -1,0 +1,77 @@
+const {app, ipcMain} = require('electron')
+const {createAuditLogService} = require('../audit/auditLogService')
+const {getPrisma} = require('../db')
+const {createRecoverySnapshotService} = require('../recovery/recoverySnapshotService')
+
+const RECOVERY_SNAPSHOT_IPC_CHANNELS = Object.freeze({
+    CREATE: 'recovery:snapshot:create',
+    LIST: 'recovery:snapshot:list',
+    READ: 'recovery:snapshot:read',
+    DELETE: 'recovery:snapshot:delete',
+    RESTORED: 'recovery:snapshot:restored',
+    POLICY: 'recovery:snapshot:policy',
+})
+
+function ok(data) {
+    return {ok: true, data, error: null}
+}
+
+function fail(error) {
+    return {
+        ok: false,
+        data: null,
+        error: {
+            code: 'RECOVERY_SNAPSHOT_ERROR',
+            message: error instanceof Error ? error.message : String(error),
+        },
+    }
+}
+
+function registerSafeRecoveryHandler(ipc, channel, handler) {
+    ipc.handle(channel, async (_event, ...args) => {
+        try {
+            return ok(await handler(...args))
+        } catch (error) {
+            return fail(error)
+        }
+    })
+}
+
+function createRecoverySnapshotHandlers({service} = {}) {
+    return {
+        createSnapshot: (input) => service.createSnapshot(input || {}),
+        listSnapshots: () => service.listSnapshots(),
+        readSnapshot: (id) => service.readSnapshot(id),
+        deleteSnapshot: (id) => service.deleteSnapshot(id),
+        markRestored: (input) => service.markRestored(input || {}),
+        getRetentionPolicy: () => service.getRetentionPolicy(),
+    }
+}
+
+function registerRecoverySnapshotHandlers({
+    ipc = ipcMain,
+    service = null,
+    auditLog = createAuditLogService({prisma: getPrisma()}),
+} = {}) {
+    const handlers = createRecoverySnapshotHandlers({
+        service: service || createRecoverySnapshotService({app, auditLog}),
+    })
+
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.CREATE, handlers.createSnapshot)
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.LIST, handlers.listSnapshots)
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.READ, handlers.readSnapshot)
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.DELETE, handlers.deleteSnapshot)
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.RESTORED, handlers.markRestored)
+    registerSafeRecoveryHandler(ipc, RECOVERY_SNAPSHOT_IPC_CHANNELS.POLICY, handlers.getRetentionPolicy)
+
+    return handlers
+}
+
+module.exports = {
+    RECOVERY_SNAPSHOT_IPC_CHANNELS,
+    createRecoverySnapshotHandlers,
+    fail,
+    ok,
+    registerRecoverySnapshotHandlers,
+    registerSafeRecoveryHandler,
+}

--- a/electron/ipc/registerWealthHandlers.js
+++ b/electron/ipc/registerWealthHandlers.js
@@ -1,8 +1,10 @@
-const {ipcMain} = require('electron')
+const {app, ipcMain} = require('electron')
 
 const {getPrisma} = require('../db')
 const {createAuditLogService} = require('../audit/auditLogService')
 const {getPortfolioDashboard} = require('../portfolio/portfolioDashboardService')
+const {createRecoverySnapshotService} = require('../recovery/recoverySnapshotService')
+const {createDatabaseRecoverySnapshot} = require('../recovery/databaseRecoveryBackup')
 const {registerGoalHandlers} = require('./registerGoalHandlers')
 const {registerMonthlySurplusHandlers} = require('./registerMonthlySurplusHandlers')
 const {registerProjectionScenarioHandlers} = require('./registerProjectionScenarioHandlers')
@@ -26,11 +28,19 @@ const {
     listNetWorthSnapshots,
 } = require('./wealthOverviewHandlers')
 
-function registerWealthHandlers(prisma = getPrisma(), {auditLog = createAuditLogService({prisma})} = {}) {
+function registerWealthHandlers(prisma = getPrisma(), {
+    auditLog = createAuditLogService({prisma}),
+    recoverySnapshots = createRecoverySnapshotService({app, auditLog}),
+} = {}) {
+    async function snapshotBefore(operationType, reason, source) {
+        return createDatabaseRecoverySnapshot({prisma, recoverySnapshots, operationType, reason, source})
+    }
+
     ipcMain.handle('db:asset:list', async (_event, filters) => listAssets(prisma, filters))
     ipcMain.handle('db:asset:create', async (_event, data) => createAsset(prisma, data))
     ipcMain.handle('db:asset:update', async (_event, id, data) => updateAsset(prisma, id, data))
     ipcMain.handle('db:asset:delete', async (_event, id) => {
+        const recovery = await snapshotBefore('delete-asset', `Suppression de l’actif ${id}`, 'db:asset:delete')
         const deleted = await deleteAsset(prisma, id)
         await auditLog.logCriticalDelete({
             domain: 'wealth',
@@ -38,7 +48,7 @@ function registerWealthHandlers(prisma = getPrisma(), {auditLog = createAuditLog
             entityId: id,
             summary: `Actif supprimé: ${deleted.name}`,
             source: 'db:asset:delete',
-            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency},
+            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency, recoverySnapshotId: recovery?.id, recoverySnapshotPath: recovery?.filePath},
         })
         return deleted
     })
@@ -46,12 +56,25 @@ function registerWealthHandlers(prisma = getPrisma(), {auditLog = createAuditLog
     ipcMain.handle('db:portfolio:list', async (_event, filters) => listPortfolios(prisma, filters))
     ipcMain.handle('db:portfolio:create', async (_event, data) => createPortfolio(prisma, data))
     ipcMain.handle('db:portfolio:update', async (_event, id, data) => updatePortfolio(prisma, id, data))
-    ipcMain.handle('db:portfolio:delete', async (_event, id) => deletePortfolio(prisma, id))
+    ipcMain.handle('db:portfolio:delete', async (_event, id) => {
+        const recovery = await snapshotBefore('delete-portfolio', `Suppression du portfolio ${id}`, 'db:portfolio:delete')
+        const deleted = await deletePortfolio(prisma, id)
+        await auditLog.logCriticalDelete({
+            domain: 'wealth',
+            entityType: 'portfolio',
+            entityId: id,
+            summary: `Portfolio supprimé: ${deleted.name}`,
+            source: 'db:portfolio:delete',
+            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency, recoverySnapshotId: recovery?.id, recoverySnapshotPath: recovery?.filePath},
+        })
+        return deleted
+    })
 
     ipcMain.handle('db:liability:list', async (_event, filters) => listLiabilities(prisma, filters))
     ipcMain.handle('db:liability:create', async (_event, data) => createLiability(prisma, data))
     ipcMain.handle('db:liability:update', async (_event, id, data) => updateLiability(prisma, id, data))
     ipcMain.handle('db:liability:delete', async (_event, id) => {
+        const recovery = await snapshotBefore('delete-liability', `Suppression du passif ${id}`, 'db:liability:delete')
         const deleted = await deleteLiability(prisma, id)
         await auditLog.logCriticalDelete({
             domain: 'wealth',
@@ -59,7 +82,7 @@ function registerWealthHandlers(prisma = getPrisma(), {auditLog = createAuditLog
             entityId: id,
             summary: `Passif supprimé: ${deleted.name}`,
             source: 'db:liability:delete',
-            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency},
+            metadata: {type: deleted.type, status: deleted.status, currency: deleted.currency, recoverySnapshotId: recovery?.id, recoverySnapshotPath: recovery?.filePath},
         })
         return deleted
     })

--- a/electron/main.js
+++ b/electron/main.js
@@ -15,6 +15,7 @@ const {registerSecretHandlers} = require('./ipc/registerSecretHandlers')
 const {registerBackupEncryptionHandlers} = require('./ipc/registerBackupEncryptionHandlers')
 const {registerAuditLogHandlers} = require('./ipc/registerAuditLogHandlers')
 const {registerIntegrityCheckHandlers} = require('./ipc/registerIntegrityCheckHandlers')
+const {registerRecoverySnapshotHandlers} = require('./ipc/registerRecoverySnapshotHandlers')
 const {disconnectPrisma} = require('./db')
 const {getMenuMessages, normalizeMenuLocale} = require('./menuI18n')
 
@@ -275,6 +276,7 @@ app.whenReady().then(() => {
     registerBackupEncryptionHandlers()
     registerAuditLogHandlers()
     registerIntegrityCheckHandlers()
+    registerRecoverySnapshotHandlers()
 
     Menu.setApplicationMenu(buildAppMenu(currentMenuLocale))
     createWindow()

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -49,7 +49,7 @@ contextBridge.exposeInMainWorld('db', {
   taxProfile: {
     list: () => ipcRenderer.invoke('db:taxProfile:list'),
     create: (data) => ipcRenderer.invoke('db:taxProfile:create', data),
-    update: (id, data) => ipcRenderer.invoke('db:taxProfile:update', id, data),
+    update: (id, data) => ipcRenderer.invoke('db:taxProfile:update', id),
     delete: (id) => ipcRenderer.invoke('db:taxProfile:delete', id),
   },
   taxMetadata: {
@@ -127,6 +127,15 @@ contextBridge.exposeInMainWorld('backupEncryption', {
   encrypt: (input) => ipcRenderer.invoke('backup:encrypted:encrypt', input),
   decrypt: (input) => ipcRenderer.invoke('backup:encrypted:decrypt', input),
   inspect: (input) => ipcRenderer.invoke('backup:encrypted:inspect', input),
+})
+
+contextBridge.exposeInMainWorld('recoverySnapshots', {
+  create: (input) => ipcRenderer.invoke('recovery:snapshot:create', input),
+  list: () => ipcRenderer.invoke('recovery:snapshot:list'),
+  read: (id) => ipcRenderer.invoke('recovery:snapshot:read', id),
+  delete: (id) => ipcRenderer.invoke('recovery:snapshot:delete', id),
+  markRestored: (input) => ipcRenderer.invoke('recovery:snapshot:restored', input),
+  getPolicy: () => ipcRenderer.invoke('recovery:snapshot:policy'),
 })
 
 contextBridge.exposeInMainWorld('auditLog', {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -49,7 +49,7 @@ contextBridge.exposeInMainWorld('db', {
   taxProfile: {
     list: () => ipcRenderer.invoke('db:taxProfile:list'),
     create: (data) => ipcRenderer.invoke('db:taxProfile:create', data),
-    update: (id, data) => ipcRenderer.invoke('db:taxProfile:update', id),
+    update: (id, data) => ipcRenderer.invoke('db:taxProfile:update', id, data),
     delete: (id) => ipcRenderer.invoke('db:taxProfile:delete', id),
   },
   taxMetadata: {

--- a/electron/recovery/databaseRecoveryBackup.js
+++ b/electron/recovery/databaseRecoveryBackup.js
@@ -1,0 +1,182 @@
+function toIso(value) {
+    if (!value) return null
+    const date = value instanceof Date ? value : new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function toDateOnly(value) {
+    const iso = toIso(value)
+    return iso ? iso.slice(0, 10) : null
+}
+
+function mapAccount(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        currency: row.currency,
+        description: row.description || null,
+        institutionCountry: row.institutionCountry || null,
+        institutionRegion: row.institutionRegion || null,
+        taxReportingType: row.taxReportingType || 'STANDARD',
+        openedAt: toDateOnly(row.openedAt),
+        closedAt: toDateOnly(row.closedAt),
+    }
+}
+
+function mapCategory(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        kind: row.kind,
+        color: row.color || null,
+        description: row.description || null,
+    }
+}
+
+function mapTransaction(row) {
+    return {
+        id: row.id,
+        label: row.label,
+        amount: Number(row.amount || 0),
+        sourceAmount: row.sourceAmount == null ? null : Number(row.sourceAmount),
+        sourceCurrency: row.sourceCurrency || null,
+        conversionMode: row.conversionMode || 'NONE',
+        exchangeRate: row.exchangeRate == null ? null : Number(row.exchangeRate),
+        exchangeProvider: row.exchangeProvider || null,
+        exchangeDate: toDateOnly(row.exchangeDate),
+        kind: row.kind,
+        date: toDateOnly(row.date),
+        note: row.note || null,
+        taxCategory: row.taxCategory || null,
+        taxSourceCountry: row.taxSourceCountry || null,
+        taxSourceRegion: row.taxSourceRegion || null,
+        taxTreatment: row.taxTreatment || 'UNKNOWN',
+        taxWithheldAmount: row.taxWithheldAmount == null ? null : Number(row.taxWithheldAmount),
+        taxWithheldCurrency: row.taxWithheldCurrency || null,
+        taxWithheldCountry: row.taxWithheldCountry || null,
+        taxDocumentRef: row.taxDocumentRef || null,
+        accountId: row.accountId,
+        categoryId: row.categoryId ?? null,
+        transferGroup: row.transferGroup || null,
+        transferDirection: row.transferDirection || null,
+        transferPeerAccountId: row.transferPeerAccountId ?? null,
+    }
+}
+
+function mapBudgetTarget(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        amount: Number(row.amount || 0),
+        period: row.period,
+        startDate: toDateOnly(row.startDate),
+        endDate: toDateOnly(row.endDate),
+        currency: row.currency,
+        isActive: row.isActive !== false,
+        note: row.note || null,
+        categoryId: row.categoryId,
+    }
+}
+
+function mapRecurringTemplate(row) {
+    return {
+        id: row.id,
+        label: row.label,
+        sourceAmount: Number(row.sourceAmount || 0),
+        sourceCurrency: row.sourceCurrency,
+        accountAmount: row.accountAmount == null ? null : Number(row.accountAmount),
+        conversionMode: row.conversionMode || 'NONE',
+        exchangeRate: row.exchangeRate == null ? null : Number(row.exchangeRate),
+        exchangeProvider: row.exchangeProvider || null,
+        kind: row.kind,
+        note: row.note || null,
+        frequency: row.frequency,
+        intervalCount: row.intervalCount || 1,
+        startDate: toDateOnly(row.startDate),
+        nextOccurrenceDate: toDateOnly(row.nextOccurrenceDate),
+        endDate: toDateOnly(row.endDate),
+        isActive: row.isActive !== false,
+        accountId: row.accountId,
+        categoryId: row.categoryId ?? null,
+    }
+}
+
+function mapTaxProfile(row) {
+    return {
+        id: row.id,
+        year: row.year,
+        residenceCountry: row.residenceCountry,
+        residenceRegion: row.residenceRegion || null,
+        currency: row.currency,
+    }
+}
+
+function emptyImportBackup(exportedAt) {
+    return {
+        schemaVersion: 1,
+        documentation: {
+            included: ['Snapshot local de récupération avant action destructive.'],
+            excluded: ['Secrets locaux', 'Mots de passe', 'Tokens et clés API'],
+            notes: ['Snapshot généré automatiquement dans le dossier userData local.'],
+        },
+        mappingTemplates: [],
+        importSources: [],
+        importHistory: [],
+        metadata: {
+            exportedAt,
+            auditOnlyRestore: true,
+            financialDataNotRestoredFromImportHistory: true,
+        },
+    }
+}
+
+async function findMany(prisma, model, options = {}) {
+    const delegate = prisma?.[model]
+    if (!delegate || typeof delegate.findMany !== 'function') return []
+    return delegate.findMany(options)
+}
+
+async function buildRecoveryBackupContent(prisma, {exportedAt = new Date().toISOString(), reason = 'recovery-snapshot'} = {}) {
+    const [accounts, categories, transactions, budgetTargets, recurringTemplates, taxProfiles] = await Promise.all([
+        findMany(prisma, 'account', {orderBy: {id: 'asc'}}),
+        findMany(prisma, 'category', {orderBy: {id: 'asc'}}),
+        findMany(prisma, 'transaction', {orderBy: {id: 'asc'}}),
+        findMany(prisma, 'budgetTarget', {orderBy: {id: 'asc'}}),
+        findMany(prisma, 'recurringTransactionTemplate', {orderBy: {id: 'asc'}}),
+        findMany(prisma, 'taxProfile', {orderBy: {id: 'asc'}}),
+    ])
+
+    return `${JSON.stringify({
+        kind: 'budget-backup',
+        version: 6,
+        exportedAt,
+        recoverySnapshot: {
+            reason,
+            secretsIncluded: false,
+        },
+        data: {
+            accounts: accounts.map(mapAccount),
+            categories: categories.map(mapCategory),
+            budgetTargets: budgetTargets.map(mapBudgetTarget),
+            recurringTemplates: recurringTemplates.map(mapRecurringTemplate),
+            transactions: transactions.map(mapTransaction),
+            taxProfiles: taxProfiles.map(mapTaxProfile),
+            financialGoals: [],
+            projectionScenarios: [],
+            projectionSettings: null,
+            importBackup: emptyImportBackup(exportedAt),
+        },
+    }, null, 2)}\n`
+}
+
+async function createDatabaseRecoverySnapshot({prisma, recoverySnapshots, operationType, reason, source}) {
+    if (!recoverySnapshots || typeof recoverySnapshots.createSnapshot !== 'function') return null
+    const content = await buildRecoveryBackupContent(prisma, {reason})
+    return recoverySnapshots.createSnapshot({content, operationType, reason, source})
+}
+
+module.exports = {
+    buildRecoveryBackupContent,
+    createDatabaseRecoverySnapshot,
+}

--- a/electron/recovery/recoverySnapshotService.js
+++ b/electron/recovery/recoverySnapshotService.js
@@ -1,0 +1,228 @@
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const {createAuditLogService} = require('../audit/auditLogService')
+
+const DEFAULT_MAX_SNAPSHOTS = 20
+const DEFAULT_MAX_BYTES = 250 * 1024 * 1024
+const SNAPSHOT_DIR_NAME = 'recovery-snapshots'
+const SECRET_KEY_RE = /secret|password|token|api[-_]?key|authorization|credential/i
+
+function safeOperation(value) {
+    return String(value || 'operation')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 48) || 'operation'
+}
+
+function snapshotTimestamp(date = new Date()) {
+    return date.toISOString().replace(/[:.]/g, '-').replace('T', '_').replace('Z', '')
+}
+
+function isRecord(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function scrubSecrets(value) {
+    if (Array.isArray(value)) return value.map(scrubSecrets)
+    if (!isRecord(value)) return value
+    return Object.fromEntries(
+        Object.entries(value)
+            .filter(([key]) => !SECRET_KEY_RE.test(key))
+            .map(([key, entry]) => [key, scrubSecrets(entry)]),
+    )
+}
+
+function sanitizeJsonContent(content) {
+    const text = String(content || '')
+    try {
+        const parsed = JSON.parse(text)
+        return `${JSON.stringify(scrubSecrets(parsed), null, 2)}\n`
+    } catch (_error) {
+        return text
+    }
+}
+
+async function pathExists(filePath) {
+    try {
+        await fs.access(filePath)
+        return true
+    } catch (_error) {
+        return false
+    }
+}
+
+async function ensureDir(dir) {
+    await fs.mkdir(dir, {recursive: true})
+}
+
+async function fileSize(filePath) {
+    try {
+        const stat = await fs.stat(filePath)
+        return stat.size
+    } catch (_error) {
+        return 0
+    }
+}
+
+function metadataPathFor(snapshotPath) {
+    return `${snapshotPath}.meta.json`
+}
+
+function createRecoverySnapshotService({app, auditLog = createAuditLogService(), clock = () => new Date(), logger = console, policy = {}} = {}) {
+    if (!app || typeof app.getPath !== 'function') throw new Error('Electron app is required for recovery snapshots')
+    const maxSnapshots = Number.isInteger(policy.maxSnapshots) && policy.maxSnapshots > 0 ? policy.maxSnapshots : DEFAULT_MAX_SNAPSHOTS
+    const maxBytes = Number.isFinite(policy.maxBytes) && policy.maxBytes > 0 ? policy.maxBytes : DEFAULT_MAX_BYTES
+
+    function directory() {
+        return path.join(app.getPath('userData'), SNAPSHOT_DIR_NAME)
+    }
+
+    async function listSnapshots() {
+        const dir = directory()
+        await ensureDir(dir)
+        const entries = await fs.readdir(dir).catch(() => [])
+        const metadataFiles = entries.filter((entry) => entry.endsWith('.meta.json'))
+        const rows = []
+
+        for (const metaFile of metadataFiles) {
+            const metaPath = path.join(dir, metaFile)
+            try {
+                const metadata = JSON.parse(await fs.readFile(metaPath, 'utf8'))
+                const snapshotPath = metadata.filePath || path.join(dir, metaFile.replace(/\.meta\.json$/, ''))
+                if (!(await pathExists(snapshotPath))) continue
+                const sizeBytes = await fileSize(snapshotPath)
+                rows.push({...metadata, filePath: snapshotPath, metadataPath: metaPath, sizeBytes})
+            } catch (error) {
+                logger?.warn?.('[recovery] invalid metadata skipped', metaPath, error)
+            }
+        }
+
+        return rows.sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')))
+    }
+
+    async function pruneSnapshots() {
+        const rows = await listSnapshots()
+        let remaining = [...rows]
+        let totalSize = remaining.reduce((sum, row) => sum + Number(row.sizeBytes || 0), 0)
+        const toDelete = []
+
+        while (remaining.length > maxSnapshots) {
+            const removed = remaining.pop()
+            if (removed) {
+                toDelete.push(removed)
+                totalSize -= Number(removed.sizeBytes || 0)
+            }
+        }
+
+        while (remaining.length && totalSize > maxBytes) {
+            const removed = remaining.pop()
+            if (removed) {
+                toDelete.push(removed)
+                totalSize -= Number(removed.sizeBytes || 0)
+            }
+        }
+
+        for (const row of toDelete) {
+            await fs.rm(row.filePath, {force: true}).catch(() => null)
+            await fs.rm(row.metadataPath || metadataPathFor(row.filePath), {force: true}).catch(() => null)
+        }
+
+        return {deletedCount: toDelete.length, retainedCount: remaining.length, maxSnapshots, maxBytes}
+    }
+
+    async function createSnapshot(input = {}) {
+        const content = sanitizeJsonContent(input.content)
+        if (!content.trim()) throw new Error('Recovery snapshot content is required')
+        const createdAt = clock().toISOString()
+        const operationType = safeOperation(input.operationType)
+        const id = `recovery-${snapshotTimestamp(new Date(createdAt))}-${operationType}`
+        const fileName = `${id}.json`
+        const dir = directory()
+        await ensureDir(dir)
+        const filePath = path.join(dir, fileName)
+        await fs.writeFile(filePath, content, 'utf8')
+        const sizeBytes = await fileSize(filePath)
+        const metadata = {
+            id,
+            fileName,
+            filePath,
+            createdAt,
+            operationType,
+            reason: String(input.reason || 'unspecified'),
+            source: String(input.source || 'renderer'),
+            sizeBytes,
+        }
+        const metadataPath = metadataPathFor(filePath)
+        await fs.writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8')
+        const retention = await pruneSnapshots()
+
+        await auditLog.recordAuditEvent({
+            eventType: 'recoverySnapshotCreated',
+            domain: 'recovery',
+            action: 'createSnapshot',
+            severity: 'WARNING',
+            status: 'SUCCESS',
+            summary: `Snapshot de récupération créé avant ${operationType}.`,
+            source: metadata.source,
+            entityIds: [{type: 'recoverySnapshot', id}],
+            metadata: {operationType, reason: metadata.reason, fileName, sizeBytes, retention},
+        })
+
+        return {...metadata, retention}
+    }
+
+    async function readSnapshot(id) {
+        const snapshot = (await listSnapshots()).find((row) => row.id === id || row.fileName === id)
+        if (!snapshot) throw new Error('Snapshot de récupération introuvable.')
+        const content = await fs.readFile(snapshot.filePath, 'utf8')
+        return {metadata: snapshot, content}
+    }
+
+    async function deleteSnapshot(id) {
+        const snapshot = (await listSnapshots()).find((row) => row.id === id || row.fileName === id)
+        if (!snapshot) return {deleted: false}
+        await fs.rm(snapshot.filePath, {force: true}).catch(() => null)
+        await fs.rm(snapshot.metadataPath || metadataPathFor(snapshot.filePath), {force: true}).catch(() => null)
+        return {deleted: true, id: snapshot.id}
+    }
+
+    async function markRestored(input = {}) {
+        await auditLog.recordAuditEvent({
+            eventType: 'recoverySnapshotRestored',
+            domain: 'recovery',
+            action: 'restoreSnapshot',
+            severity: 'CRITICAL',
+            status: 'SUCCESS',
+            summary: 'Snapshot de récupération chargé dans le flow de restauration.',
+            source: input.source || 'renderer',
+            entityIds: [{type: 'recoverySnapshot', id: input.id || input.filePath || 'unknown'}],
+            metadata: {filePath: input.filePath || null},
+        })
+        return {ok: true}
+    }
+
+    function getRetentionPolicy() {
+        return {maxSnapshots, maxBytes, directory: directory()}
+    }
+
+    return {
+        createSnapshot,
+        deleteSnapshot,
+        getRetentionPolicy,
+        listSnapshots,
+        markRestored,
+        pruneSnapshots,
+        readSnapshot,
+    }
+}
+
+module.exports = {
+    DEFAULT_MAX_BYTES,
+    DEFAULT_MAX_SNAPSHOTS,
+    SNAPSHOT_DIR_NAME,
+    createRecoverySnapshotService,
+    scrubSecrets,
+    sanitizeJsonContent,
+}

--- a/src/components/RecoverySnapshotsPanel.vue
+++ b/src/components/RecoverySnapshotsPanel.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import {onMounted, ref} from 'vue'
+
+interface IpcResult<T> {
+  ok: boolean
+  data: T | null
+  error: {message?: string; code?: string} | null
+}
+
+interface RecoverySnapshotRow {
+  id: string
+  fileName: string
+  filePath: string
+  createdAt: string
+  operationType: string
+  reason: string
+  source: string
+  sizeBytes: number
+}
+
+interface RecoverySnapshotPolicy {
+  maxSnapshots: number
+  maxBytes: number
+  directory: string
+}
+
+const emit = defineEmits<{ notice: [type: 'success' | 'error', text: string] }>()
+
+const loading = ref(false)
+const exporting = ref<string | null>(null)
+const deleting = ref<string | null>(null)
+const snapshots = ref<RecoverySnapshotRow[]>([])
+const policy = ref<RecoverySnapshotPolicy | null>(null)
+
+function unwrap<T>(result: IpcResult<T> | T, fallback: string): T {
+  if (result && typeof result === 'object' && 'ok' in result) {
+    const ipc = result as IpcResult<T>
+    if (ipc.ok && ipc.data != null) return ipc.data
+    throw new Error(ipc.error?.message || fallback)
+  }
+  return result as T
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('fr-CA', {dateStyle: 'medium', timeStyle: 'short'}).format(date)
+}
+
+function formatBytes(value: number | null | undefined) {
+  const bytes = Number(value || 0)
+  if (bytes < 1024) return `${bytes} o`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} Ko`
+  return `${Math.round(bytes / 1024 / 1024)} Mo`
+}
+
+async function loadSnapshots() {
+  const api = window.recoverySnapshots
+  if (!api) return
+  loading.value = true
+  try {
+    snapshots.value = unwrap(await api.list(), 'Impossible de lire les snapshots de récupération.')
+    policy.value = unwrap(await api.getPolicy(), 'Impossible de lire la politique de rétention.')
+  } catch (error) {
+    emit('notice', 'error', error instanceof Error ? error.message : 'Impossible de lire les snapshots de récupération.')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function exportSnapshot(row: RecoverySnapshotRow) {
+  const api = window.recoverySnapshots
+  if (!api) return
+  exporting.value = row.id
+  try {
+    const snapshot = unwrap(await api.read(row.id), 'Impossible de lire le snapshot.') as {metadata: RecoverySnapshotRow; content: string}
+    const result = await window.file.saveText({
+      title: 'Exporter un snapshot de récupération',
+      defaultPath: row.fileName,
+      content: snapshot.content,
+      filters: [{name: 'JSON', extensions: ['json']}],
+    })
+    if (!result?.canceled) emit('notice', 'success', 'Snapshot exporté. Tu peux le restaurer avec le flow JSON existant.')
+  } catch (error) {
+    emit('notice', 'error', error instanceof Error ? error.message : 'Échec de l’export du snapshot.')
+  } finally {
+    exporting.value = null
+  }
+}
+
+async function markRestored(row: RecoverySnapshotRow) {
+  const api = window.recoverySnapshots
+  if (!api) return
+  try {
+    unwrap(await api.markRestored({id: row.id, filePath: row.filePath, source: 'recovery-snapshots-panel'}), 'Impossible d’auditer le snapshot.')
+    emit('notice', 'success', 'Évènement de restauration snapshot audité. Exporte le snapshot puis restaure-le via JSON si nécessaire.')
+  } catch (error) {
+    emit('notice', 'error', error instanceof Error ? error.message : 'Impossible d’auditer le snapshot.')
+  }
+}
+
+async function deleteSnapshot(row: RecoverySnapshotRow) {
+  const api = window.recoverySnapshots
+  if (!api) return
+  const accepted = window.confirm(`Supprimer le snapshot local ${row.fileName} ? Cette action ne supprime aucune donnée financière.`)
+  if (!accepted) return
+  deleting.value = row.id
+  try {
+    unwrap(await api.delete(row.id), 'Impossible de supprimer le snapshot.')
+    await loadSnapshots()
+    emit('notice', 'success', 'Snapshot supprimé.')
+  } catch (error) {
+    emit('notice', 'error', error instanceof Error ? error.message : 'Impossible de supprimer le snapshot.')
+  } finally {
+    deleting.value = null
+  }
+}
+
+onMounted(loadSnapshots)
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/60">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+          Récupération locale
+        </p>
+        <h4 class="mt-1 text-sm font-bold text-slate-900 dark:text-white">
+          Snapshots avant actions critiques
+        </h4>
+        <p class="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+          Budget crée automatiquement un backup JSON local avant les suppressions critiques et les restores complets. Les secrets locaux ne sont pas inclus.
+        </p>
+        <p v-if="policy" class="mt-1 text-[11px] text-slate-400">
+          Rétention : {{ policy.maxSnapshots }} snapshots · {{ formatBytes(policy.maxBytes) }} max · {{ policy.directory }}
+        </p>
+      </div>
+      <button class="ghost-btn !px-3 !py-2 text-xs" :disabled="loading" @click="loadSnapshots">
+        {{ loading ? 'Chargement…' : 'Rafraîchir' }}
+      </button>
+    </div>
+
+    <div v-if="snapshots.length" class="mt-4 space-y-2">
+      <article
+          v-for="snapshot in snapshots"
+          :key="snapshot.id"
+          class="rounded-2xl border border-slate-200 bg-white p-3 text-xs dark:border-slate-800 dark:bg-slate-950/60"
+      >
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div class="min-w-0">
+            <p class="truncate font-bold text-slate-900 dark:text-white">{{ snapshot.fileName }}</p>
+            <p class="mt-1 text-slate-500 dark:text-slate-400">
+              {{ snapshot.operationType }} · {{ formatDate(snapshot.createdAt) }} · {{ formatBytes(snapshot.sizeBytes) }}
+            </p>
+            <p class="mt-1 text-slate-500 dark:text-slate-400">{{ snapshot.reason }}</p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button class="mini-action-btn" :disabled="exporting === snapshot.id" @click="exportSnapshot(snapshot)">
+              {{ exporting === snapshot.id ? 'Export…' : 'Exporter' }}
+            </button>
+            <button class="mini-action-btn" @click="markRestored(snapshot)">
+              Auditer restore
+            </button>
+            <button class="mini-danger-btn" :disabled="deleting === snapshot.id" @click="deleteSnapshot(snapshot)">
+              {{ deleting === snapshot.id ? 'Suppression…' : 'Supprimer' }}
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <p v-else class="mt-4 rounded-xl border border-dashed border-slate-300 px-3 py-4 text-center text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+      Aucun snapshot de récupération pour l’instant.
+    </p>
+  </section>
+</template>

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -63,7 +63,7 @@ const {t} = useI18n()
           </select>
         </div>
 
-        <RecoverySnapshotsPanel @notice="emit('notice', $event, arguments[1])" />
+        <RecoverySnapshotsPanel @notice="(type, text) => emit('notice', type, text)" />
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/60">
           <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">

--- a/src/components/SettingsDialog.vue
+++ b/src/components/SettingsDialog.vue
@@ -2,6 +2,7 @@
 import {useI18n} from 'vue-i18n'
 import FreshnessBadge from './provenance/FreshnessBadge.vue'
 import ProvenanceBadge from './provenance/ProvenanceBadge.vue'
+import RecoverySnapshotsPanel from './RecoverySnapshotsPanel.vue'
 import type {SupportedLocale} from '../i18n'
 
 const props = defineProps<{
@@ -14,6 +15,7 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'update-locale', value: SupportedLocale): void
   (e: 'update-theme', value: 'light' | 'dark'): void
+  (e: 'notice', type: 'success' | 'error', text: string): void
 }>()
 
 const {t} = useI18n()
@@ -25,7 +27,7 @@ const {t} = useI18n()
       class="dialog-backdrop"
       @click.self="emit('close')"
   >
-    <div class="dialog-card">
+    <div class="dialog-card max-h-[90vh] overflow-y-auto">
       <p class="soft-kicker">
         {{ t('settings.subtitle') }}
       </p>
@@ -60,6 +62,8 @@ const {t} = useI18n()
             <option value="dark">{{ t('settings.themeDark') }}</option>
           </select>
         </div>
+
+        <RecoverySnapshotsPanel @notice="emit('notice', $event, arguments[1])" />
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/60">
           <p class="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">

--- a/src/test/electron/recoverySnapshotService.test.js
+++ b/src/test/electron/recoverySnapshotService.test.js
@@ -1,0 +1,115 @@
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const {createRecoverySnapshotService, sanitizeJsonContent} = require('../../../electron/recovery/recoverySnapshotService')
+
+const tempDirs = []
+
+async function tempUserData() {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'budget-recovery-'))
+    tempDirs.push(dir)
+    return dir
+}
+
+function fakeApp(userData) {
+    return {
+        getPath(name) {
+            if (name !== 'userData') throw new Error(`unexpected path ${name}`)
+            return userData
+        },
+    }
+}
+
+afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+        await fs.rm(dir, {recursive: true, force: true})
+    }
+})
+
+describe('recovery snapshot service', () => {
+    it('creates local snapshots, scrubs secrets and writes audit events', async () => {
+        const userData = await tempUserData()
+        const auditLog = {recordAuditEvent: vi.fn(async () => null)}
+        const service = createRecoverySnapshotService({
+            app: fakeApp(userData),
+            auditLog,
+            clock: () => new Date('2026-05-11T12:00:00.000Z'),
+        })
+
+        const snapshot = await service.createSnapshot({
+            operationType: 'delete-account',
+            reason: 'Suppression test',
+            source: 'unit-test',
+            content: JSON.stringify({kind: 'budget-backup', apiKey: 'secret-value', data: {accounts: []}}),
+        })
+
+        expect(snapshot.id).toContain('delete-account')
+        expect(snapshot.filePath).toContain('recovery-snapshots')
+        const content = await fs.readFile(snapshot.filePath, 'utf8')
+        expect(content).toContain('budget-backup')
+        expect(content).not.toContain('secret-value')
+        expect(content).not.toContain('apiKey')
+        expect(auditLog.recordAuditEvent).toHaveBeenCalledWith(expect.objectContaining({
+            eventType: 'recoverySnapshotCreated',
+            domain: 'recovery',
+            status: 'SUCCESS',
+            entityIds: [{type: 'recoverySnapshot', id: snapshot.id}],
+        }))
+    })
+
+    it('lists, reads and deletes snapshots', async () => {
+        const userData = await tempUserData()
+        const service = createRecoverySnapshotService({
+            app: fakeApp(userData),
+            auditLog: {recordAuditEvent: vi.fn(async () => null)},
+            clock: () => new Date('2026-05-11T12:00:00.000Z'),
+        })
+        const snapshot = await service.createSnapshot({operationType: 'restore-full', reason: 'before restore', content: '{"ok":true}'})
+
+        const listed = await service.listSnapshots()
+        expect(listed).toHaveLength(1)
+        expect(listed[0]).toMatchObject({id: snapshot.id, operationType: 'restore-full'})
+
+        const read = await service.readSnapshot(snapshot.id)
+        expect(read.content).toContain('ok')
+
+        await expect(service.deleteSnapshot(snapshot.id)).resolves.toMatchObject({deleted: true, id: snapshot.id})
+        await expect(service.listSnapshots()).resolves.toEqual([])
+    })
+
+    it('enforces count retention by deleting oldest snapshots', async () => {
+        const userData = await tempUserData()
+        let minute = 0
+        const service = createRecoverySnapshotService({
+            app: fakeApp(userData),
+            auditLog: {recordAuditEvent: vi.fn(async () => null)},
+            clock: () => new Date(Date.UTC(2026, 4, 11, 12, minute++, 0)),
+            policy: {maxSnapshots: 2, maxBytes: 1024 * 1024},
+        })
+
+        await service.createSnapshot({operationType: 'first', reason: 'one', content: '{"n":1}'})
+        await service.createSnapshot({operationType: 'second', reason: 'two', content: '{"n":2}'})
+        await service.createSnapshot({operationType: 'third', reason: 'three', content: '{"n":3}'})
+
+        const rows = await service.listSnapshots()
+        expect(rows).toHaveLength(2)
+        expect(rows.map((row) => row.operationType)).toEqual(['third', 'second'])
+    })
+
+    it('sanitizes nested secret-like keys from backup JSON', () => {
+        const sanitized = sanitizeJsonContent(JSON.stringify({
+            metadata: {
+                token: 'hidden',
+                nested: {password: 'hidden', visible: true},
+            },
+            data: {accounts: []},
+        }))
+
+        expect(sanitized).toContain('visible')
+        expect(sanitized).not.toContain('hidden')
+        expect(sanitized).not.toContain('password')
+        expect(sanitized).not.toContain('token')
+    })
+})

--- a/src/types/recovery-window.d.ts
+++ b/src/types/recovery-window.d.ts
@@ -1,0 +1,52 @@
+export {}
+
+interface RecoverySnapshotMetadataDto {
+    id: string
+    fileName: string
+    filePath: string
+    metadataPath?: string
+    createdAt: string
+    operationType: string
+    reason: string
+    source: string
+    sizeBytes: number
+}
+
+interface RecoverySnapshotPolicyDto {
+    maxSnapshots: number
+    maxBytes: number
+    directory: string
+}
+
+interface RecoverySnapshotReadDto {
+    metadata: RecoverySnapshotMetadataDto
+    content: string
+}
+
+interface RecoverySnapshotIpcResultDto<T> {
+    ok: boolean
+    data: T | null
+    error: {code: string; message: string} | null
+}
+
+declare global {
+    interface Window {
+        recoverySnapshots?: {
+            create: (input: {
+                content: string
+                operationType: string
+                reason: string
+                source?: string
+            }) => Promise<RecoverySnapshotIpcResultDto<RecoverySnapshotMetadataDto>>
+            list: () => Promise<RecoverySnapshotIpcResultDto<RecoverySnapshotMetadataDto[]>>
+            read: (id: string) => Promise<RecoverySnapshotIpcResultDto<RecoverySnapshotReadDto>>
+            delete: (id: string) => Promise<RecoverySnapshotIpcResultDto<{deleted: boolean; id?: string}>>
+            markRestored: (input: {
+                id?: string
+                filePath?: string
+                source?: string
+            }) => Promise<RecoverySnapshotIpcResultDto<{ok: boolean}>>
+            getPolicy: () => Promise<RecoverySnapshotIpcResultDto<RecoverySnapshotPolicyDto>>
+        }
+    }
+}


### PR DESCRIPTION
Closes #98

## Summary
- add a local recovery snapshot service stored under Electron `userData/recovery-snapshots`
- scrub secret-like keys from JSON snapshot content before writing it locally
- add sidecar metadata with timestamp, operation type, reason, source and size
- add simple retention by max snapshot count and max total size
- expose recovery snapshot IPC handlers and preload API
- create a local recovery snapshot before critical account/transaction deletes and wealth asset/portfolio/liability deletes
- include recovery snapshot metadata in critical delete audit events
- add a settings panel to list, export, audit and delete recovery snapshots
- add tests for snapshot creation, secret scrubbing, list/read/delete and retention

## Notes
- Restore is intentionally routed through the existing JSON restore flow: export a recovery snapshot from Settings, then restore it with the normal JSON restore path.
- The existing full-restore flow already creates a pre-restore backup; this PR adds the new controlled userData snapshot system and wires it to destructive backend deletes first.

## Tests
- Not run locally: repository dependency install/build was not available in this environment.