### PR TITLE
test/docs: harden security recovery trust coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Le projet est construit avec :
 - **projections descriptives** : les calculs dépendent d’hypothèses visibles et ne sont pas des conseils financiers
 
 Le modèle de sécurité et de récupération local est documenté dans [`docs/security-model.md`](docs/security-model.md).
+Les tests, fixtures et limites de confiance sont documentés dans [`docs/security-trust-testing.md`](docs/security-trust-testing.md), avec une checklist release dédiée dans [`docs/release-security-checklist.md`](docs/release-security-checklist.md).
 
 ## Fonctionnalités
 
@@ -95,6 +96,20 @@ La documentation dédiée est disponible ici : [`docs/goals-projections.md`](doc
 Documentation dédiée : [`docs/import-pipeline.md`](docs/import-pipeline.md).
 
 Fichiers de démonstration : [`docs/demo/imports`](docs/demo/imports).
+
+### Sécurité et récupération locales
+
+- centre “Sécurité & récupération” dans les paramètres
+- backup JSON et backup chiffré par mot de passe
+- restore avec dry-run avant écriture
+- audit log exportable
+- vérification d’intégrité applicative
+- snapshots locaux avant actions critiques couvertes
+- stockage local de secrets exposé uniquement via métadonnées côté renderer
+
+Limites explicites : pas de cloud sync, pas d’authentification utilisateur intégrée, pas de récupération d’un mot de passe de backup chiffré perdu, et les snapshots locaux ne remplacent pas une sauvegarde externe.
+
+Documentation : [`docs/security-model.md`](docs/security-model.md), [`docs/security-trust-testing.md`](docs/security-trust-testing.md).
 
 ### Rapports
 
@@ -199,6 +214,12 @@ Tests ciblés import :
 npm run test:run -- src/test/electron/importPipelineFixtures.test.js src/test/electron/importWorkflowIpc.test.js src/test/utils/importCsvPresets.test.ts
 ````
 
+Tests ciblés sécurité/récupération :
+
+````shell
+npm run test:run -- src/test/electron/backupEncryption.test.js src/test/electron/secretStore.test.js src/test/electron/integrityCheckService.test.js src/test/electron/recoverySnapshotService.test.js src/test/electron/securityTrustFixtures.test.js src/test/utils/backupIntegrity.test.ts src/test/utils/provenance.test.ts src/test/utils/domainProvenance.test.ts src/test/components/securityRecoveryPanel.test.ts
+````
+
 ## Vérification TypeScript
 
 ````shell
@@ -226,6 +247,7 @@ npm run make
 ````
 
 Le process complet est documenté dans [`docs/release-flow.md`](docs/release-flow.md).
+La checklist sécurité/récupération avant release est dans [`docs/release-security-checklist.md`](docs/release-security-checklist.md).
 
 ## Notes base de données
 

--- a/docs/release-security-checklist.md
+++ b/docs/release-security-checklist.md
@@ -1,0 +1,44 @@
+# Release security and recovery checklist
+
+À exécuter avant une release qui touche backups, restore, audit, intégrité, secrets, provenance ou snapshots.
+
+## Tests automatisés
+
+- [ ] `npm run test:run`
+- [ ] `npm run typecheck`
+- [ ] Tests ciblés sécurité :
+
+```shell
+npm run test:run -- src/test/electron/backupEncryption.test.js src/test/electron/secretStore.test.js src/test/electron/integrityCheckService.test.js src/test/electron/recoverySnapshotService.test.js src/test/electron/securityTrustFixtures.test.js src/test/utils/backupIntegrity.test.ts src/test/utils/provenance.test.ts src/test/utils/domainProvenance.test.ts src/test/components/securityRecoveryPanel.test.ts
+```
+
+## Vérifications manuelles
+
+- [ ] Exporter un backup JSON non chiffré depuis l’app.
+- [ ] Relire ce backup via le flow restore dry-run sans l’appliquer.
+- [ ] Exporter un backup chiffré.
+- [ ] Restaurer le backup chiffré avec le bon mot de passe.
+- [ ] Vérifier qu’un mauvais mot de passe échoue proprement.
+- [ ] Tenter un restore avec un backup corrompu et vérifier que l’erreur arrive avant écriture.
+- [ ] Lancer le check d’intégrité depuis Paramètres > Sécurité & récupération.
+- [ ] Supprimer une entité critique dans une base de test et vérifier qu’un snapshot local est créé.
+- [ ] Exporter l’audit log et vérifier qu’il ne contient pas de secret brut.
+- [ ] Vérifier que les secrets locaux affichés dans l’UI sont seulement des métadonnées.
+- [ ] Vérifier que les textes UI rappellent les limites locales : pas de cloud sync, pas de récupération de mot de passe perdu, snapshots locaux uniquement.
+- [ ] Vérifier que les fixtures dans `src/test/fixtures/security` ne contiennent aucune donnée réelle.
+
+## Packaging
+
+- [ ] `npm run release:check`
+- [ ] `npm run package`
+- [ ] Démarrer le package local et refaire au moins un export JSON, un export chiffré et un restore dry-run.
+
+## Décision release
+
+Ne pas releaser si :
+
+- un mauvais mot de passe peut produire un succès silencieux ;
+- un backup corrompu peut atteindre une écriture partielle ;
+- un secret brut apparaît dans audit, backup, snapshot ou UI ;
+- les messages promettent plus que le modèle local ne garantit ;
+- les snapshots ne sont pas créés avant les actions critiques déjà couvertes.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -4,6 +4,8 @@ Ce document cadre le modèle de sécurité local de Budget. Il sert de référen
 
 Budget est une application desktop **local-first**. Le modèle vise donc à protéger des données financières sensibles stockées ou manipulées localement, sans promettre une sécurité cloud, enterprise ou multi-utilisateur.
 
+Les tests, fixtures et vérifications manuelles associés à ce modèle sont documentés dans [`security-trust-testing.md`](security-trust-testing.md) et [`release-security-checklist.md`](release-security-checklist.md).
+
 ## Objectifs
 
 - rendre explicite ce que l’application protège ;

--- a/docs/security-trust-testing.md
+++ b/docs/security-trust-testing.md
@@ -1,0 +1,77 @@
+# Security, recovery and trust testing
+
+Cette page complète le modèle de sécurité local de Budget. Elle décrit les tests et vérifications attendus pour les backups, la restauration, les secrets locaux, l’audit, l’intégrité, la provenance et les snapshots.
+
+Budget est local-first. Ces mécanismes réduisent les risques d’erreur, de corruption ou de perte locale. Ils ne remplacent pas une sauvegarde externe, le chiffrement disque ou un audit indépendant.
+
+## Couverture automatisée
+
+| Domaine | Vérification attendue | Tests concernés |
+| --- | --- | --- |
+| Secrets locaux | valeurs jamais exposées dans la metadata, fallback local identifié, coffre corrompu géré | `secretStore.test.js` |
+| Backups chiffrés | roundtrip, mauvais mot de passe, contenu modifié, version inconnue | `backupEncryption.test.js` |
+| Restore dry-run | backup valide, legacy, corrompu, erreurs bloquantes | `restoreDryRun.test.ts`, `securityTrustFixtures.test.js` |
+| Intégrité | références manquantes, montants invalides, transferts cassés, audit critique | `integrityCheckService.test.js` |
+| Audit log | événements lisibles, export, rétention, pas de secrets | tests audit/import existants |
+| Provenance/fraîcheur | fresh, stale, unknown, userProvided, unavailable | `provenance.test.ts`, `domainProvenance.test.ts` |
+| Snapshots | création locale, metadata, rétention, nettoyage des clés sensibles | `recoverySnapshotService.test.js` |
+| Paramètres sécurité | actions regroupées, check manuel, limites visibles | `securityRecoveryPanel.test.ts` |
+
+## Fixtures
+
+Les fixtures sont dans `src/test/fixtures/security`.
+
+- `valid-backup-v6.json` : backup v6 minimal cohérent.
+- `legacy-backup-v2.json` : ancien format supporté.
+- `corrupted-backup.json` : JSON invalide pour tester les erreurs avant restore.
+- `incoherent-database.json` : dataset cassé pour tests d’intégrité.
+
+Le backup chiffré de test est généré pendant les tests depuis `valid-backup-v6.json` avec le mot de passe `fixture-password`. Ce mot de passe est réservé aux tests.
+
+## Points à prouver
+
+### Backup JSON
+
+Un backup JSON non chiffré est portable et lisible. Il doit être validé avant restore, mais il n’est pas confidentiel.
+
+### Backup chiffré
+
+Un backup chiffré doit cacher le contenu clair, échouer avec un mauvais mot de passe et refuser les fichiers modifiés. Budget ne peut pas récupérer un mot de passe perdu.
+
+### Restore dry-run
+
+Le dry-run est le garde-fou avant écriture. Il doit afficher les erreurs bloquantes, warnings, compteurs et éléments ignorés.
+
+### Audit log
+
+L’audit doit expliquer les actions importantes sans contenir de valeurs secrètes ou dumps inutiles.
+
+### Integrity check
+
+Le check d’intégrité détecte des incohérences applicatives connues. Il ne prouve pas que les données financières sont exactes.
+
+### Provenance et fraîcheur
+
+La provenance indique l’origine et la fraîcheur d’une donnée. Elle ne garantit pas que la source externe était correcte.
+
+### Snapshots locaux
+
+Les snapshots aident à revenir après certaines actions destructrices locales. Ils ne remplacent pas une sauvegarde hors machine.
+
+## Commandes ciblées
+
+```shell
+npm run test:run -- src/test/electron/backupEncryption.test.js src/test/electron/secretStore.test.js src/test/electron/integrityCheckService.test.js src/test/electron/recoverySnapshotService.test.js src/test/electron/securityTrustFixtures.test.js src/test/utils/backupIntegrity.test.ts src/test/utils/provenance.test.ts src/test/utils/domainProvenance.test.ts src/test/components/securityRecoveryPanel.test.ts
+```
+
+```shell
+npm run typecheck
+```
+
+## Formulations produit à conserver
+
+- Dire “local”, pas “cloud”.
+- Dire “chiffré par mot de passe”, pas “récupérable”.
+- Dire “snapshot local”, pas “sauvegarde garantie”.
+- Dire “check d’intégrité applicatif”, pas “preuve absolue”.
+- Dire “audit lisible”, pas “audit de conformité”.

--- a/src/test/electron/securityTrustFixtures.test.js
+++ b/src/test/electron/securityTrustFixtures.test.js
@@ -1,0 +1,81 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+
+const fixtureDir = path.join(process.cwd(), 'src/test/fixtures/security')
+
+function readFixture(name) {
+    return fs.readFileSync(path.join(fixtureDir, name), 'utf8')
+}
+
+function readJsonFixture(name) {
+    return JSON.parse(readFixture(name))
+}
+
+describe('security and trust fixtures', () => {
+    it('keeps the valid backup fixture parseable by the restore parser', async () => {
+        const {parseBudgetBackupWithImportData} = await import('../../utils/importJsonBackup')
+        const {createRestoreDryRunReport} = await import('../../utils/restoreDryRun')
+
+        const parsed = parseBudgetBackupWithImportData(readFixture('valid-backup-v6.json'))
+        const report = createRestoreDryRunReport(parsed)
+
+        expect(parsed.version).toBe(6)
+        expect(parsed.data.accounts).toHaveLength(1)
+        expect(report.canApply).toBe(true)
+        expect(report.blockingErrors).toEqual([])
+    })
+
+    it('keeps the legacy backup fixture restorable through compatibility parsing', async () => {
+        const {parseBudgetBackupWithImportData} = await import('../../utils/importJsonBackup')
+        const {createRestoreDryRunReport} = await import('../../utils/restoreDryRun')
+
+        const parsed = parseBudgetBackupWithImportData(readFixture('legacy-backup-v2.json'))
+        const report = createRestoreDryRunReport(parsed)
+
+        expect(parsed.version).toBe(6)
+        expect(report.canApply).toBe(true)
+        expect(report.integrity?.status).toBe('legacy')
+    })
+
+    it('keeps the corrupted backup fixture rejected before restore', async () => {
+        const {parseBudgetBackupWithImportData} = await import('../../utils/importJsonBackup')
+
+        expect(() => parseBudgetBackupWithImportData(readFixture('corrupted-backup.json')))
+            .toThrow(/JSON est invalide|corrompu/i)
+    })
+
+    it('generates an encrypted fixture from the valid backup and rejects wrong passwords', () => {
+        const {
+            BACKUP_ENCRYPTION_ERROR_CODES,
+            decryptBackupJson,
+            encryptBackupJson,
+            parseEncryptedBackup,
+            serializeEncryptedBackup,
+        } = require('../../../electron/security/backupEncryption')
+        const backupJson = readFixture('valid-backup-v6.json')
+
+        const envelope = encryptBackupJson(backupJson, 'fixture-password', {
+            now: () => new Date('2026-05-11T12:00:00.000Z'),
+            metadata: {source: 'fixture-test', backupVersion: 6},
+        })
+        const serialized = serializeEncryptedBackup(envelope)
+        const parsed = parseEncryptedBackup(serialized)
+
+        expect(JSON.stringify(parsed)).not.toContain('Fixture Checking')
+        expect(JSON.stringify(parsed)).not.toContain('fixture-password')
+        expect(JSON.parse(decryptBackupJson(parsed, 'fixture-password'))).toEqual(JSON.parse(backupJson))
+        expect(() => decryptBackupJson(parsed, 'bad-password')).toThrow(expect.objectContaining({
+            code: BACKUP_ENCRYPTION_ERROR_CODES.WRONG_PASSWORD,
+        }))
+    })
+
+    it('documents an incoherent database fixture for integrity checks', () => {
+        const fixture = readJsonFixture('incoherent-database.json')
+
+        expect(fixture.accounts[0].currency).toBe('CA')
+        expect(fixture.transactions.some((transaction) => transaction.accountId === 99)).toBe(true)
+        expect(fixture.budgetTargets[0].categoryId).toBe(99)
+        expect(fixture.recurringTransactionTemplate[0].intervalCount).toBe(0)
+    })
+})

--- a/src/test/fixtures/security/README.md
+++ b/src/test/fixtures/security/README.md
@@ -1,0 +1,20 @@
+# Security, recovery and trust fixtures
+
+Ces fixtures servent aux tests de l’epic 7. Elles sont volontairement petites et lisibles pour permettre de reproduire rapidement les cas de backup, restore, intégrité et récupération.
+
+## Fichiers
+
+- `valid-backup-v6.json` : backup v6 minimal mais cohérent, utilisable pour restore dry-run et tests de chiffrement.
+- `legacy-backup-v2.json` : ancien format supporté pour vérifier la compatibilité legacy.
+- `corrupted-backup.json` : JSON volontairement invalide pour tester les erreurs de parsing/restauration.
+- `incoherent-database.json` : dataset incohérent pour tests d’intégrité, avec références manquantes, dates invalides et transfert incomplet.
+
+## Backup chiffré de test
+
+Les tests génèrent le backup chiffré à partir de `valid-backup-v6.json` avec le mot de passe de test `fixture-password`.
+
+Ne pas réutiliser ce mot de passe en production. Il existe uniquement pour rendre les tests reproductibles.
+
+## Règle de sécurité
+
+Aucune fixture ne doit contenir de vrai secret, token, compte bancaire réel, identifiant personnel ou export utilisateur réel.

--- a/src/test/fixtures/security/corrupted-backup.json
+++ b/src/test/fixtures/security/corrupted-backup.json
@@ -1,0 +1,1 @@
+{"kind":"budget-backup","version":6,"exportedAt":"2026-05-11T12:00:00.000Z","data":{"accounts":[{"id":1,"name":"Broken"}],"transactions":[}

--- a/src/test/fixtures/security/incoherent-database.json
+++ b/src/test/fixtures/security/incoherent-database.json
@@ -1,0 +1,18 @@
+{
+  "accounts": [
+    {"id": 1, "name": "Broken Account", "currency": "CA", "openedAt": "2026-05-01", "closedAt": "2026-04-01"}
+  ],
+  "categories": [
+    {"id": 1, "name": "Groceries", "kind": "EXPENSE"}
+  ],
+  "transactions": [
+    {"id": 1, "label": "Missing account", "amount": -10, "sourceAmount": 10, "sourceCurrency": "CAD", "exchangeRate": 1, "exchangeDate": "bad-date", "kind": "INCOME", "date": "bad-date", "accountId": 99, "categoryId": 1, "transferGroup": null, "transferDirection": null, "transferPeerAccountId": null},
+    {"id": 2, "label": "Broken transfer", "amount": 25, "sourceAmount": 25, "sourceCurrency": "CAD", "exchangeRate": 1, "exchangeDate": "2026-05-01", "kind": "TRANSFER", "date": "2026-05-01", "accountId": 1, "categoryId": null, "transferGroup": "broken-transfer", "transferDirection": "OUT", "transferPeerAccountId": 99}
+  ],
+  "budgetTargets": [
+    {"id": 1, "name": "Bad budget", "amount": 100, "currency": "CAD", "startDate": "2026-06-01", "endDate": "2026-05-01", "categoryId": 99}
+  ],
+  "recurringTransactionTemplate": [
+    {"id": 1, "label": "Bad recurring", "sourceAmount": 0, "sourceCurrency": "CAD", "accountAmount": null, "exchangeRate": null, "kind": "EXPENSE", "intervalCount": 0, "startDate": "2026-05-01", "nextOccurrenceDate": "2026-04-01", "endDate": null, "accountId": 99, "categoryId": 99}
+  ]
+}

--- a/src/test/fixtures/security/legacy-backup-v2.json
+++ b/src/test/fixtures/security/legacy-backup-v2.json
@@ -1,0 +1,17 @@
+{
+  "kind": "budget-backup",
+  "version": 2,
+  "exportedAt": "2025-12-01T09:00:00.000Z",
+  "data": {
+    "accounts": [
+      {"id": 1, "name": "Legacy Account", "type": "BANK", "currency": "CAD", "description": null}
+    ],
+    "categories": [
+      {"id": 1, "name": "Legacy Expense", "kind": "EXPENSE", "color": null, "description": null}
+    ],
+    "budgetTargets": [],
+    "recurringTemplates": [],
+    "transactions": [],
+    "taxProfiles": []
+  }
+}

--- a/src/test/fixtures/security/valid-backup-v6.json
+++ b/src/test/fixtures/security/valid-backup-v6.json
@@ -1,0 +1,33 @@
+{
+  "kind": "budget-backup",
+  "version": 6,
+  "exportedAt": "2026-05-11T12:00:00.000Z",
+  "data": {
+    "accounts": [
+      {"id": 1, "name": "Fixture Checking", "type": "BANK", "currency": "CAD", "description": null}
+    ],
+    "categories": [
+      {"id": 1, "name": "Income", "kind": "INCOME", "color": null, "description": null},
+      {"id": 2, "name": "Groceries", "kind": "EXPENSE", "color": null, "description": null}
+    ],
+    "budgetTargets": [
+      {"id": 1, "name": "Groceries monthly", "amount": 500, "period": "MONTHLY", "startDate": "2026-05-01", "endDate": null, "currency": "CAD", "isActive": true, "note": null, "categoryId": 2}
+    ],
+    "recurringTemplates": [],
+    "transactions": [
+      {"id": 1, "label": "Fixture salary", "amount": 1000, "sourceAmount": null, "sourceCurrency": null, "conversionMode": "NONE", "exchangeRate": 1, "exchangeProvider": "ACCOUNT", "exchangeDate": "2026-05-01", "kind": "INCOME", "date": "2026-05-01", "note": null, "accountId": 1, "categoryId": 1}
+    ],
+    "taxProfiles": [],
+    "financialGoals": [],
+    "projectionScenarios": [],
+    "projectionSettings": null,
+    "importBackup": {
+      "schemaVersion": 1,
+      "documentation": {"included": ["Fixture import audit"], "excluded": ["Secrets"], "notes": ["Test fixture only"]},
+      "mappingTemplates": [],
+      "importSources": [],
+      "importHistory": [],
+      "metadata": {"exportedAt": "2026-05-11T12:00:00.000Z", "auditOnlyRestore": true, "financialDataNotRestoredFromImportHistory": true}
+    }
+  }
+}


### PR DESCRIPTION
Closes #100

## Summary
- add reusable security/trust fixtures for valid backup v6, legacy backup v2, corrupted backup JSON, and incoherent integrity data
- add fixture tests covering restore parsing, dry-run acceptance, legacy compatibility, corrupted backup rejection, encrypted backup generation, wrong password failure, and incoherent integrity data shape
- document the fixture set and the rule that no real data/secrets should be committed
- add `docs/security-trust-testing.md` covering critical security/recovery test expectations and honest product wording
- add `docs/release-security-checklist.md` for manual pre-release checks around backup, encrypted backup, restore, integrity, audit, snapshots and secrets
- update README to link the security docs and targeted test command
- link the trust-testing docs from the local security model

## Notes
- The encrypted backup fixture is generated during tests instead of storing a large opaque ciphertext blob in the repository.
- Documentation intentionally avoids overpromising: local-first protections, no password recovery, no cloud/IAM guarantee, snapshots are not external backups.

## Tests
- Not run locally: repository dependency install/build was not available in this environment.